### PR TITLE
Ensure FireEvent prunes tied weights

### DIFF
--- a/components/fire_event.py
+++ b/components/fire_event.py
@@ -56,7 +56,7 @@ class FireEvent:
                 if k > flat_abs.numel():
                     k = flat_abs.numel()
                 threshold, _ = torch.kthvalue(flat_abs, k)
-                mask = param.data.abs() < threshold
+                mask = param.data.abs() <= threshold
                 pruned = mask.sum().item()
                 if pruned > 0:
                     param.data[mask] = 0.0

--- a/tests/test_fire_event.py
+++ b/tests/test_fire_event.py
@@ -1,0 +1,26 @@
+import torch
+import torch.nn as nn
+
+from components.fire_event import FireEvent
+
+
+def test_fire_event_prunes_at_least_k_weights():
+    layer = nn.Linear(2, 3, bias=False)
+    with torch.no_grad():
+        layer.weight.copy_(
+            torch.tensor(
+                [
+                    [0.1, 0.2],
+                    [0.2, 0.2],
+                    [0.3, 0.4],
+                ]
+            )
+        )
+
+    prune_fraction = 0.5
+    FireEvent.apply(layer, prune_fraction=prune_fraction, threshold_scale=1.0)
+
+    zero_count = (layer.weight == 0).sum().item()
+    expected_pruned = max(1, int(prune_fraction * layer.weight.numel()))
+
+    assert zero_count >= expected_pruned


### PR DESCRIPTION
## Summary
- update FireEvent pruning mask to include weights that tie the pruning threshold
- add a unit test confirming that pruning zeroes at least the expected number of weights

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9d59a9aac832c84662d778e86a826