### PR TITLE
Ensure RobustTrainer injects adversary during updates

### DIFF
--- a/tests/test_robust_trainer.py
+++ b/tests/test_robust_trainer.py
@@ -1,0 +1,172 @@
+import os
+import sys
+
+import torch
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from utils.robust_trainer import RobustTrainer
+
+
+class DummyActionSpace:
+    def sample(self):
+        return torch.zeros(1).numpy()
+
+
+class DummyEnv:
+    action_space = DummyActionSpace()
+    internal_dim = 1
+    action_dim = 1
+    num_constraints = 1
+
+
+class DummyReplayBuffer:
+    def __init__(self, batch_size, sequence_length):
+        self.batch_size = batch_size
+        self.sequence_length = sequence_length
+
+    def sample_sequence_batch(self, batch_size, sequence_length):
+        device = torch.device('cpu')
+        obs_seq = torch.zeros(batch_size, sequence_length, 1, device=device)
+        action_seq = torch.zeros(batch_size, sequence_length, 1, device=device)
+        next_obs_seq = torch.zeros(batch_size, sequence_length, 1, device=device)
+        internal_state_seq = torch.zeros(batch_size, sequence_length, 1, device=device)
+        next_internal_state_seq = torch.zeros(batch_size, sequence_length, 1, device=device)
+        unsafe_action_seq = torch.zeros(batch_size, sequence_length, 1, device=device)
+        viability_label_seq = torch.zeros(batch_size, sequence_length, device=device)
+        violations_seq = torch.zeros(batch_size, sequence_length, 1, device=device)
+        constraint_margins_seq = torch.zeros(batch_size, sequence_length, 1, device=device)
+        return {
+            'obs_seq': obs_seq,
+            'action_seq': action_seq,
+            'next_obs_seq': next_obs_seq,
+            'internal_state_seq': internal_state_seq,
+            'next_internal_state_seq': next_internal_state_seq,
+            'unsafe_action_seq': unsafe_action_seq,
+            'viability_label_seq': viability_label_seq,
+            'violations_seq': violations_seq,
+            'constraint_margins_seq': constraint_margins_seq,
+        }
+
+    def sample_batch(self, batch_size):
+        device = torch.device('cpu')
+        zeros = torch.zeros(batch_size, 1, device=device)
+        return {
+            'obs': zeros,
+            'next_obs': zeros,
+            'internal_state': zeros,
+            'next_internal_state': zeros,
+            'action': zeros,
+            'reward': torch.zeros(batch_size, device=device),
+            'done': torch.zeros(batch_size, dtype=torch.bool, device=device),
+        }
+
+
+class DummyWorldModel:
+    def train_model(self, *args, **kwargs):
+        pass
+
+    def encoder(self, obs):
+        return torch.zeros(obs.shape[0], 1)
+
+    def transition(self, z, action):
+        return z
+
+
+class DummyIntrinsicModule:
+    def train_predictor(self, obs):
+        pass
+
+
+class DummyInternalModel:
+    def train_model(self, *args, **kwargs):
+        pass
+
+
+class DummyViabilityApproximator:
+    def train_on_demonstrations(self, *args, **kwargs):
+        pass
+
+    def train_model(self, *args, **kwargs):
+        pass
+
+    def get_margin(self, internal_states):
+        return torch.zeros(internal_states.shape[0])
+
+
+class DummySafetyNetwork:
+    def train_network(self, *args, **kwargs):
+        pass
+
+
+class RecordingAgent:
+    def __init__(self):
+        self.learn_calls = 0
+        self.last_adversary = None
+        self.last_data = None
+
+    def learn(self, data, ewc_penalty, adversary=None):
+        self.learn_calls += 1
+        self.last_adversary = adversary
+        self.last_data = data
+        return 0.0
+
+
+class DummyNearBoundaryBuffer:
+    def __len__(self):
+        return 0
+
+
+class DummyDemonstrationBuffer:
+    def __len__(self):
+        return 0
+
+
+class DummyConstraintManager:
+    def update(self, *args, **kwargs):
+        pass
+
+
+class DummySafetyProbe:
+    def train_probe(self, *args, **kwargs):
+        pass
+
+
+def make_trainer(adversary):
+    batch_size = 2
+    sequence_length = 3
+    components = {
+        'config': {
+            'training': {'batch_size': batch_size},
+            'state_estimator': {'sequence_length': sequence_length},
+            'rewards': {'intrinsic': 'rnd'},
+            'env': {'partial_observability': False},
+        },
+        'device': torch.device('cpu'),
+        'env': DummyEnv(),
+        'replay_buffer': DummyReplayBuffer(batch_size, sequence_length),
+        'world_model': DummyWorldModel(),
+        'intrinsic_reward_module': DummyIntrinsicModule(),
+        'internal_model': DummyInternalModel(),
+        'viability_approximator': DummyViabilityApproximator(),
+        'viability_ensemble': [],
+        'safety_network': DummySafetyNetwork(),
+        'agent': RecordingAgent(),
+        'continual_learning_manager': None,
+        'demonstration_buffer': DummyDemonstrationBuffer(),
+        'near_boundary_buffer': DummyNearBoundaryBuffer(),
+        'constraint_manager': None,
+        'safety_probe': None,
+        'adversary': adversary,
+    }
+    return RobustTrainer(components)
+
+
+def test_update_models_passes_adversary_to_agent():
+    adversary = object()
+    trainer = make_trainer(adversary)
+
+    trainer.update_models()
+
+    assert trainer.agent.learn_calls == 1
+    assert trainer.agent.last_adversary is adversary

--- a/utils/robust_trainer.py
+++ b/utils/robust_trainer.py
@@ -1,3 +1,4 @@
+import numpy as np
 import torch
 from utils.trainer import Trainer
 
@@ -12,20 +13,21 @@ class RobustTrainer(Trainer):
         else:
             print("⚠️ RobustTrainer initialized, but no Adversary component was found.")
 
-    def _update_models(self):
-        """
-        Overrides the base trainer's update method to include adversarial training.
-        """
-        # 1. Sample batch and update other models (same as base class)
-        # This logic is mostly copied from the parent, with one key change for the agent update.
+    def update_models(self):
+        """Run a full model update while injecting the adversarial learn step."""
 
-        # Sample batch
+        # 1. Sample sequence batch for model updates
         seq_batch = self.replay_buffer.sample_sequence_batch(self.batch_size, self.sequence_length)
-        obs_seq, act_seq, next_obs_seq = seq_batch['obs_seq'], seq_batch['act_seq'], seq_batch['next_obs_seq']
-        true_internal_state_seq, true_next_internal_state_seq = seq_batch['internal_state_seq'], seq_batch['next_internal_state_seq']
-        unsafe_act_seq, viability_label_seq = seq_batch['unsafe_action_seq'], seq_batch['viability_label_seq']
 
-        # Update state estimator
+        obs_seq = seq_batch['obs_seq']
+        act_seq = seq_batch['action_seq']
+        next_obs_seq = seq_batch['next_obs_seq']
+        true_internal_state_seq = seq_batch['internal_state_seq']
+        true_next_internal_state_seq = seq_batch['next_internal_state_seq']
+        unsafe_act_seq = seq_batch['unsafe_action_seq']
+        viability_label_seq = seq_batch['viability_label_seq']
+
+        # 2. Update the state estimator if necessary
         if self.is_partially_observable:
             act_seq_lagged = torch.cat([torch.zeros_like(act_seq[:, :1]), act_seq[:, :-1]], dim=1)
             with torch.no_grad():
@@ -34,37 +36,107 @@ class RobustTrainer(Trainer):
         else:
             estimated_internal_state_seq = true_internal_state_seq
 
-        # Update world model and intrinsic module
+        # 3. Update world model and intrinsic reward module (mirrors base implementation)
         self.world_model.train_model(obs_seq[:, 0], act_seq[:, 0], next_obs_seq[:, 0])
-        # ... (intrinsic module updates are complex and remain the same)
 
-        # Update safety models
+        intrinsic_method = self.config['rewards']['intrinsic']
+        if intrinsic_method == 'rnd':
+            self.intrinsic_reward_module.train_predictor(obs_seq[:, 0])
+        elif intrinsic_method == 'empowerment':
+            with torch.no_grad():
+                z_batch = self.world_model.encoder(obs_seq[:, 0])
+                k = self.intrinsic_reward_module.k
+                action_sequences_batch = torch.stack([
+                    torch.from_numpy(np.array([self.env.action_space.sample() for _ in range(k)]))
+                    for _ in range(self.batch_size)
+                ]).float().to(self.device)
+
+                current_z_batch = z_batch
+                for i in range(k):
+                    actions_for_rollout = action_sequences_batch[:, i, :]
+                    current_z_batch = self.world_model.transition(current_z_batch, actions_for_rollout)
+                z_future_batch = current_z_batch
+            self.intrinsic_reward_module.update(
+                z_batch.detach(), action_sequences_batch, z_future_batch.detach()
+            )
+
+        # 4. Update safety-related components
         flat_est_internal = estimated_internal_state_seq.reshape(-1, self.env.internal_dim)
         flat_true_next_internal = true_next_internal_state_seq.reshape(-1, self.env.internal_dim)
         flat_act = act_seq.reshape(-1, self.env.action_dim)
         flat_unsafe_act = unsafe_act_seq.reshape(-1, self.env.action_dim)
         flat_viability_label = viability_label_seq.reshape(-1)
         violations_seq = seq_batch['violations_seq']
-        flat_violations = violations_seq.reshape(-1, self.env.internal_dim)
+        flat_violations = violations_seq.reshape(-1, self.env.num_constraints)
+        constraint_margins_seq = seq_batch['constraint_margins_seq']
+        flat_constraint_margins = constraint_margins_seq.reshape(-1, self.env.num_constraints)
 
         self.internal_model.train_model(flat_est_internal, flat_act, flat_true_next_internal)
+
+        if self.safety_probe:
+            self.safety_probe.train_probe(flat_est_internal.detach(), flat_constraint_margins)
+
+        if self.demonstration_buffer and len(self.demonstration_buffer) > 0:
+            self.viability_approximator.train_on_demonstrations(self.demonstration_buffer, self.batch_size)
         self.viability_approximator.train_model(flat_est_internal, flat_viability_label)
+
         if self.viability_ensemble:
             for model in self.viability_ensemble:
+                if self.demonstration_buffer and len(self.demonstration_buffer) > 0:
+                    model.train_on_demonstrations(self.demonstration_buffer, self.batch_size)
                 model.train_model(flat_est_internal, flat_viability_label)
+
+        if self.near_boundary_buffer and len(self.near_boundary_buffer) > 0:
+            nb_states, nb_labels = self.near_boundary_buffer.sample(self.batch_size)
+            if nb_states.numel() > 0:
+                self.viability_approximator.train_model(nb_states, nb_labels)
+                if self.viability_ensemble:
+                    for model in self.viability_ensemble:
+                        model.train_model(nb_states, nb_labels)
+
         if self.constraint_manager:
             self.constraint_manager.update(flat_violations)
+
         self.safety_network.train_network(
             unsafe_actions=flat_unsafe_act,
             safe_actions=flat_act,
             internal_states=flat_est_internal
         )
 
-        # 5. Update agent with adversarial examples
+        # 5. Prepare agent batch and include adversary in learning call
         batch = self.replay_buffer.sample_batch(self.batch_size)
-        ewc_penalty = self.continual_learning_manager.penalty() if self.continual_learning_manager else 0.0
 
-        # *** The key change is here: pass the adversary to the agent's learn method ***
-        policy_entropy = self.agent.learn(data=batch, ewc_penalty=ewc_penalty, adversary=self.adversary)
+        agent_data = batch
+        if self.is_partially_observable:
+            obs = torch.cat([batch['obs'], batch['internal_state']], dim=1)
+            next_obs = torch.cat([batch['next_obs'], batch['next_internal_state']], dim=1)
+            agent_data = {
+                'obs': obs,
+                'action': batch['action'],
+                'reward': batch['reward'],
+                'next_obs': next_obs,
+                'done': batch['done']
+            }
+
+        ewc_penalty = 0.0
+        if self.continual_learning_manager:
+            ewc_penalty = self.continual_learning_manager.penalty()
+
+        policy_entropy = self.agent.learn(
+            data=agent_data,
+            ewc_penalty=ewc_penalty,
+            adversary=getattr(self, 'adversary', None)
+        )
+
+        if hasattr(self, 'telemetry_manager') and self.telemetry_manager:
+            with torch.no_grad():
+                margins = self.viability_approximator.get_margin(flat_est_internal)
+                near_boundary_mask = (margins > 0.1) & (margins < 0.9)
+                near_boundary_samples_count = near_boundary_mask.sum().item()
+
+            self.telemetry_manager.update_on_model_update(
+                policy_entropy=policy_entropy,
+                near_boundary_samples_count=near_boundary_samples_count
+            )
 
         return policy_entropy


### PR DESCRIPTION
## Summary
- replace the unused `_update_models` helper with a full `update_models` override that mirrors the base trainer flow
- make the agent learning step accept the configured adversary so robust logic executes during coordinator updates
- add a regression test covering that the trainer forwards its adversary to the agent during updates

## Testing
- pytest tests/test_robust_trainer.py

------
https://chatgpt.com/codex/tasks/task_e_68d9dbef4614832cafcd5a6584d55f6d