### PR TITLE
Fix resource allocator factory configuration

### DIFF
--- a/multiagent/resource_allocator.py
+++ b/multiagent/resource_allocator.py
@@ -27,8 +27,18 @@ class ResourceAllocator:
         self._resources = resource_config.copy()
         self.mode = allocator_config.get('mode', 'none')
         self.alpha = allocator_config.get('alpha', 1.0) # For alpha-fairness
+        self.fairness = allocator_config.get('fairness')
+        self.tax = allocator_config.get('tax', 0.0)
+        self.conflict_resolution = allocator_config.get('conflict_resolution')
         self._lock = threading.Lock()
-        logger.info(f"ResourceAllocator initialized in '{self.mode}' mode with resources: {self._resources}")
+        logger.info(
+            "ResourceAllocator initialized in '%s' mode with resources: %s | fairness=%s, tax=%s, conflict_resolution=%s",
+            self.mode,
+            self._resources,
+            self.fairness,
+            self.tax,
+            self.conflict_resolution,
+        )
 
     def get_quotas(self, agent_states):
         """

--- a/tests/test_resource_allocator_factory.py
+++ b/tests/test_resource_allocator_factory.py
@@ -1,0 +1,39 @@
+import pathlib
+import sys
+
+import pytest
+
+PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from utils.factory import ComponentFactory
+from multiagent.resource_allocator import ResourceAllocator
+
+
+def test_factory_creates_configured_resource_allocator():
+    """Ensure the factory forwards allocator settings from the config file."""
+
+    config_path = pathlib.Path(__file__).resolve().parents[1] / "config.yaml"
+    factory = ComponentFactory(config_path=str(config_path))
+    allocator_cfg = factory.config['resource_allocator']
+    allocator_cfg.update({
+        'mode': 'proportional',
+        'alpha': 1.7,
+        'fairness': 'alpha_fair',
+        'tax': 0.05,
+        'conflict_resolution': 'priority',
+    })
+
+    allocator = factory.create_resource_allocator()
+
+    assert isinstance(allocator, ResourceAllocator)
+    assert allocator.mode == allocator_cfg['mode']
+    assert allocator.alpha == allocator_cfg['alpha']
+    assert allocator.fairness == allocator_cfg['fairness']
+    assert pytest.approx(allocator.tax) == allocator_cfg['tax']
+    assert allocator.conflict_resolution == allocator_cfg['conflict_resolution']
+
+    resources = allocator.get_all_resources()
+    assert 'food' in resources
+

--- a/utils/factory.py
+++ b/utils/factory.py
@@ -498,11 +498,19 @@ class ComponentFactory:
         if allocator_config.get('mode', 'none') == 'none':
             return None
 
-        resource_config = {
-            'food': self.config['resource_model']['food']['initial_density'] * 10 * 10
-        }
+        resource_model_config = self.config.get('resource_model', {})
+        resource_config = {}
 
-        allocator = ResourceAllocator(resource_config)
+        if resource_model_config:
+            grid_width = self.config.get('multiagent', {}).get('grid_width', 10)
+            grid_height = self.config.get('multiagent', {}).get('grid_height', 10)
+            total_cells = grid_width * grid_height
+
+            for resource_name, resource_settings in resource_model_config.items():
+                density = resource_settings.get('initial_density', 0.0)
+                resource_config[resource_name] = density * total_cells
+
+        allocator = ResourceAllocator(resource_config, allocator_config)
         print("✅ Resource allocator initialized.")
         return allocator
 


### PR DESCRIPTION
## Summary
- forward the factory's allocator configuration into `ResourceAllocator`
- expose allocator fairness, tax, and conflict resolution settings on the allocator
- cover the factory path with a regression test to ensure a configured allocator is built when enabled

## Testing
- pytest tests/test_resource_allocator_factory.py

------
https://chatgpt.com/codex/tasks/task_e_68d9dcfe3148832c8a66bbc6af4dc71e