### PR TITLE
Add agent persistence accessors and regression test

### DIFF
--- a/agents/cvar_sac.py
+++ b/agents/cvar_sac.py
@@ -204,3 +204,28 @@ class CVAR_SAC(nn.Module):
 
         # Return policy entropy for logging
         return -logp_pi.detach().mean().item()
+
+    def get_state(self):
+        return self.state_dict()
+
+    def load_state(self, state):
+        if state:
+            self.load_state_dict(state)
+
+    def get_optimizers(self):
+        return {
+            'actor': self.actor_optimizer,
+            'critic': self.critic_optimizer,
+            'alpha': self.alpha_optimizer,
+        }
+
+    def get_optimizer_state(self):
+        return {name: optimizer.state_dict() for name, optimizer in self.get_optimizers().items()}
+
+    def load_optimizer_state(self, state):
+        if not state:
+            return
+        for name, optimizer in self.get_optimizers().items():
+            optimizer_state = state.get(name)
+            if optimizer_state:
+                optimizer.load_state_dict(optimizer_state)

--- a/agents/mpc_agent.py
+++ b/agents/mpc_agent.py
@@ -51,3 +51,19 @@ class MPCAgent:
         separately in the main training loop. This method is a no-op.
         """
         pass
+
+    def get_state(self):
+        return {}
+
+    def load_state(self, state):
+        # The MPC agent has no trainable parameters to restore.
+        return
+
+    def get_optimizer_state(self):
+        return {}
+
+    def load_optimizer_state(self, state):
+        return
+
+    def get_optimizers(self):
+        return {}

--- a/agents/sac.py
+++ b/agents/sac.py
@@ -165,3 +165,28 @@ class SAC(nn.Module):
 
         # Return policy entropy for logging
         return -logp_pi.detach().mean().item()
+
+    def get_state(self):
+        return self.state_dict()
+
+    def load_state(self, state):
+        if state:
+            self.load_state_dict(state)
+
+    def get_optimizers(self):
+        return {
+            'actor': self.actor_optimizer,
+            'critic': self.critic_optimizer,
+            'alpha': self.alpha_optimizer,
+        }
+
+    def get_optimizer_state(self):
+        return {name: optimizer.state_dict() for name, optimizer in self.get_optimizers().items()}
+
+    def load_optimizer_state(self, state):
+        if not state:
+            return
+        for name, optimizer in self.get_optimizers().items():
+            optimizer_state = state.get(name)
+            if optimizer_state:
+                optimizer.load_state_dict(optimizer_state)

--- a/agents/shared_sac.py
+++ b/agents/shared_sac.py
@@ -173,3 +173,28 @@ class SharedSAC(nn.Module):
                 p_target.data.add_((1 - polyak) * p.data)
 
         return -logp_pi.detach().mean().item()
+
+    def get_state(self):
+        return self.state_dict()
+
+    def load_state(self, state):
+        if state:
+            self.load_state_dict(state)
+
+    def get_optimizers(self):
+        return {
+            'actor': self.actor_optimizer,
+            'critic': self.critic_optimizer,
+            'alpha': self.alpha_optimizer,
+        }
+
+    def get_optimizer_state(self):
+        return {name: optimizer.state_dict() for name, optimizer in self.get_optimizers().items()}
+
+    def load_optimizer_state(self, state):
+        if not state:
+            return
+        for name, optimizer in self.get_optimizers().items():
+            optimizer_state = state.get(name)
+            if optimizer_state:
+                optimizer.load_state_dict(optimizer_state)

--- a/systems/coordinator.py
+++ b/systems/coordinator.py
@@ -206,7 +206,7 @@ class ExperimentCoordinator:
             'episode': episode,
             'total_steps': self.total_steps,
             'agent_state_dict': self.agent.get_state(),
-            'optimizer_state_dict': self.agent.optimizer.state_dict(),
+            'optimizer_state_dict': self.agent.get_optimizer_state(),
         }
         self.persistence_manager.save_checkpoint(state, self.total_steps)
 
@@ -219,7 +219,7 @@ class ExperimentCoordinator:
             self.start_episode = state.get('episode', 0) + 1
             self.total_steps = state.get('total_steps', 0)
             self.agent.load_state(state.get('agent_state_dict'))
-            if hasattr(self.agent, 'optimizer') and 'optimizer_state_dict' in state:
-                self.agent.optimizer.load_state_dict(state['optimizer_state_dict'])
+            if 'optimizer_state_dict' in state:
+                self.agent.load_optimizer_state(state['optimizer_state_dict'])
             print(f"--- Resumed from checkpoint at episode {self.start_episode}, step {self.total_steps} ---")
         return state

--- a/systems/persistence.py
+++ b/systems/persistence.py
@@ -1,6 +1,7 @@
 import os
 import torch
 import hashlib
+import zlib
 import json
 import logging
 from datetime import datetime
@@ -41,7 +42,7 @@ class PersistenceManager:
     def _calculate_crc32(self, filepath):
         """Calculates the CRC32 checksum of a file."""
         with open(filepath, "rb") as f:
-            file_hash = hashlib.crc32(f.read())
+            file_hash = zlib.crc32(f.read())
         return file_hash
 
     def save_checkpoint(self, state, step):

--- a/tests/test_persistence_cycle.py
+++ b/tests/test_persistence_cycle.py
@@ -1,0 +1,67 @@
+import copy
+import sys
+from pathlib import Path
+
+import torch
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from agents.persist_agent import PersistAgent
+from systems.persistence import PersistenceManager
+
+
+def _assert_nested_equal(expected, actual):
+    if isinstance(expected, dict):
+        assert isinstance(actual, dict)
+        assert set(expected.keys()) == set(actual.keys())
+        for key in expected:
+            _assert_nested_equal(expected[key], actual[key])
+    elif isinstance(expected, (list, tuple)):
+        assert isinstance(actual, type(expected))
+        assert len(expected) == len(actual)
+        for expected_item, actual_item in zip(expected, actual):
+            _assert_nested_equal(expected_item, actual_item)
+    elif torch.is_tensor(expected):
+        torch.testing.assert_close(expected, actual)
+    else:
+        assert expected == actual
+
+
+def test_persist_agent_checkpoint_cycle(tmp_path):
+    agent = PersistAgent(obs_dim=4, act_dim=2, act_limit=1.0)
+    agent.to(torch.device("cpu"))
+
+    persistence_manager = PersistenceManager(tmp_path)
+
+    checkpoint = {
+        'episode': 0,
+        'total_steps': 1,
+        'agent_state_dict': agent.get_state(),
+        'optimizer_state_dict': agent.get_optimizer_state(),
+    }
+
+    expected_agent_state = {key: value.clone() for key, value in checkpoint['agent_state_dict'].items()}
+    expected_optimizer_state = copy.deepcopy(checkpoint['optimizer_state_dict'])
+
+    persistence_manager.save_checkpoint(checkpoint, checkpoint['total_steps'])
+    assert persistence_manager.has_checkpoints()
+
+    for param in agent.policy.actor.parameters():
+        param.data.zero_()
+    for optimizer in agent.get_optimizers().values():
+        optimizer.state.clear()
+
+    loaded = persistence_manager.load_latest_checkpoint()
+    assert loaded is not None
+
+    agent.load_state(loaded['agent_state_dict'])
+    agent.load_optimizer_state(loaded['optimizer_state_dict'])
+
+    reloaded_agent_state = agent.get_state()
+    for key, expected_tensor in expected_agent_state.items():
+        torch.testing.assert_close(expected_tensor, reloaded_agent_state[key])
+
+    reloaded_optimizer_state = agent.get_optimizer_state()
+    _assert_nested_equal(expected_optimizer_state, reloaded_optimizer_state)


### PR DESCRIPTION
## Summary
- add delegated state and optimizer accessors across agent implementations
- update the coordinator checkpoint logic and fix checksum handling for persistence
- add a regression test that exercises a checkpoint save/load cycle with the default agent

## Testing
- pytest tests/test_persistence_cycle.py

------
https://chatgpt.com/codex/tasks/task_e_68d9df06d54c832c9aee93f6bba1eda2