### PR TITLE
Support running multi-agent training with EEA policy

### DIFF
--- a/agents/eea_agent.py
+++ b/agents/eea_agent.py
@@ -13,6 +13,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Callable, Dict, List, Mapping, Optional, Tuple
 
+import numpy as np
+
 
 def _clamp(value: float, lower: float = 0.0, upper: float = 1.0) -> float:
     """Clamp ``value`` between ``lower`` and ``upper`` (inclusive)."""
@@ -49,7 +51,11 @@ class EmotionState:
     def effective_happiness(self) -> float:
         """Return the happiness signal after modulation if available."""
 
-        return self.modulated_happiness if self.modulated_happiness is not None else self.happiness
+        return (
+            self.modulated_happiness
+            if self.modulated_happiness is not None
+            else self.happiness
+        )
 
     def effective_fear(self) -> float:
         """Return the fear signal after modulation if available."""
@@ -217,7 +223,7 @@ class ProcessingLayer:
         # Feedback A – anticipation: fear sharpens reward acquisition
         happiness += fear * self.anticipation_gain
         # Feedback B – reinforcement: successful avoidance reduces fear
-        fear *= (1.0 - self.reinforcement_gain)
+        fear *= 1.0 - self.reinforcement_gain
 
         # Feedback C – calibration: push toward stable ratio
         ratio = state.ratio()
@@ -249,7 +255,9 @@ class ContextWeights:
 class IntegrationLayer:
     """Contextualizes signals using environment, social, and internal weights."""
 
-    def integrate(self, state: EmotionState, context_weights: ContextWeights) -> EmotionState:
+    def integrate(
+        self, state: EmotionState, context_weights: ContextWeights
+    ) -> EmotionState:
         weights = context_weights.normalize()
         happiness = state.effective_happiness()
         fear = state.effective_fear()
@@ -279,7 +287,9 @@ class OutputLayer:
     def __post_init__(self) -> None:
         lo, hi = self.vital_range
         if not (0.0 <= self.apathy_threshold <= lo <= hi <= 1.0):
-            raise ValueError("Behavior thresholds must satisfy apathy <= vital_range <= 1.0")
+            raise ValueError(
+                "Behavior thresholds must satisfy apathy <= vital_range <= 1.0"
+            )
         if not (hi <= self.mania_threshold <= 1.0):
             raise ValueError("Mania threshold must be >= vital_range[1] and <= 1.0")
 
@@ -306,7 +316,9 @@ class MetaLayer:
     equilibrium_prior: float = 0.75
 
     def update(self, observed_ratio: float) -> float:
-        self.equilibrium_prior = (1 - self.smoothing) * self.equilibrium_prior + self.smoothing * observed_ratio
+        self.equilibrium_prior = (
+            1 - self.smoothing
+        ) * self.equilibrium_prior + self.smoothing * observed_ratio
         return self.equilibrium_prior
 
     def reset(self, *, equilibrium_prior: Optional[float] = None) -> None:
@@ -453,9 +465,131 @@ class EmotionalEquilibriumAgent:
         }
 
 
+class EEAMultiAgentPolicy:
+    """Heuristic multi-agent controller driven by the EEA scaffold."""
+
+    def __init__(
+        self, env, *, num_agents: int, config: Mapping[str, object] | None = None
+    ) -> None:
+        self.env = env
+        self.num_agents = num_agents
+        self.config = config if config is not None else {}
+
+        vision_space = env.single_observation_space.spaces["vision"]
+        self._vision_shape = vision_space.shape
+        self._vision_size = int(np.prod(self._vision_shape))
+        self._center = np.array(
+            [
+                self._vision_shape[0] // 2,
+                self._vision_shape[1] // 2,
+            ]
+        )
+
+        seed = self.config.get("seed") if isinstance(self.config, Mapping) else None
+        self._rng = np.random.default_rng(seed)
+        self._agents = [EmotionalEquilibriumAgent() for _ in range(num_agents)]
+
+    def reset(self) -> None:
+        for agent in self._agents:
+            agent.reset()
+
+    def get_action(
+        self, obs: np.ndarray, agent_id: int, deterministic: bool = False
+    ) -> np.ndarray:
+        obs = np.asarray(obs, dtype=np.float32)
+        vision, internal_state, neighbor_stats, time_scalar = self._split_obs(obs)
+
+        food_channel = vision[..., 0]
+        hazard_channel = vision[..., 1]
+        agent_channel = vision[..., 2]
+
+        happiness = _clamp(float(internal_state[0]))
+        hazard_signal = float(
+            np.clip(hazard_channel.mean() + 0.25 * agent_channel.mean(), 0.0, 1.0)
+        )
+        context = {
+            "neighbor_density": float(np.mean(neighbor_stats)),
+            "time": float(time_scalar),
+            "food_density": float(food_channel.mean()),
+        }
+
+        eea_result = self._agents[agent_id].evaluate(
+            happiness=happiness,
+            fear=hazard_signal,
+            context=context,
+        )
+        behavior = eea_result["behavior"]
+
+        move: np.ndarray = np.zeros(2, dtype=np.float32)
+        if behavior is BehaviorState.ANXIETY:
+            move = self._toward_high_value(food_channel)
+        elif behavior is BehaviorState.MANIA:
+            move = self._wander(deterministic)
+        else:  # Vital engagement and fallback
+            move = self._toward_high_value(food_channel)
+            if np.allclose(move, 0.0):
+                move = self._wander(deterministic, scale=0.5)
+
+        return move.astype(np.float32)
+
+    def update(self, data) -> None:  # pragma: no cover - heuristic policy is stateless
+        return None
+
+    def state_dict(
+        self,
+    ) -> Dict[str, object]:  # pragma: no cover - interface compatibility
+        return {}
+
+    def load_state_dict(
+        self, state: Mapping[str, object] | None
+    ) -> None:  # pragma: no cover
+        return None
+
+    def get_optimizer_state(self) -> Dict[str, object]:  # pragma: no cover
+        return {}
+
+    def load_optimizer_state(
+        self, state: Mapping[str, object] | None
+    ) -> None:  # pragma: no cover
+        return None
+
+    def _split_obs(
+        self, obs: np.ndarray
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, float]:
+        vision = obs[: self._vision_size].reshape(self._vision_shape)
+        idx = self._vision_size
+
+        internal_state = obs[idx : idx + 3]
+        idx += 3
+
+        neighbor_stats = obs[idx : idx + 3]
+        idx += 3
+
+        time_scalar = float(obs[idx]) if idx < len(obs) else 0.0
+        return vision, internal_state, neighbor_stats, time_scalar
+
+    def _toward_high_value(self, food_channel: np.ndarray) -> np.ndarray:
+        if food_channel.size == 0 or np.max(food_channel) <= 0.0:
+            return np.zeros(2, dtype=np.float32)
+
+        targets = np.argwhere(food_channel == np.max(food_channel))
+        if targets.size == 0:
+            return np.zeros(2, dtype=np.float32)
+
+        target = targets[0]
+        delta = target - self._center
+        return np.clip(delta, -1.0, 1.0).astype(np.float32)
+
+    def _wander(self, deterministic: bool, scale: float = 1.0) -> np.ndarray:
+        if deterministic:
+            return np.zeros(2, dtype=np.float32)
+        return self._rng.uniform(low=-scale, high=scale, size=2).astype(np.float32)
+
+
 __all__ = [
     "EmotionalEquilibriumAgent",
     "EmotionState",
     "ContextWeights",
     "BehaviorState",
+    "EEAMultiAgentPolicy",
 ]

--- a/environments/multi_agent_gridlife.py
+++ b/environments/multi_agent_gridlife.py
@@ -24,10 +24,10 @@ class MultiAgentGridLifeEnv(gym.Env):
 
         # Vision + internal state + neighbor features + time
         view_radius = self.config['multiagent']['observation']['view_radius']
-        obs_shape = (2 * view_radius + 1, 2 * view_radius + 1)
+        vision_shape = (2 * view_radius + 1, 2 * view_radius + 1, 3)
 
         self.single_observation_space = Dict({
-            "vision": Box(low=0, high=10, shape=obs_shape, dtype=np.float32),
+            "vision": Box(low=0, high=10, shape=vision_shape, dtype=np.float32),
             "x": Box(low=0, high=1, shape=(3,), dtype=np.float32), # energy, temp, integrity
             "neighbors": Box(low=0, high=self.num_agents, shape=(3,), dtype=np.float32), # count, competition, resource_density
             "time": Box(low=0, high=1, shape=(1,), dtype=np.float32)

--- a/tests/test_eea_multiagent_policy.py
+++ b/tests/test_eea_multiagent_policy.py
@@ -1,0 +1,69 @@
+import numpy as np
+
+from agents.eea_agent import EEAMultiAgentPolicy
+from environments.multi_agent_gridlife import MultiAgentGridLifeEnv
+
+
+def create_config(num_agents: int = 2):
+    return {
+        "seed": 123,
+        "multiagent": {
+            "num_agents": num_agents,
+            "observation": {"view_radius": 2},
+            "termination": {"max_steps": 25},
+        },
+        "agent_types": {
+            "default": {
+                "policy": "eea_agent",
+                "homeostasis": {"mu": [0.7, 0.5, 0.9]},
+            }
+        },
+        "resource_model": {
+            "food": {"initial_density": 0.2},
+        },
+    }
+
+
+def _flatten_obs(obs_dict):
+    return np.concatenate(
+        [
+            obs_dict["vision"].flatten(),
+            obs_dict["x"],
+            obs_dict["neighbors"],
+            obs_dict["time"],
+        ]
+    )
+
+
+def test_eea_policy_produces_bounded_actions():
+    config = create_config(num_agents=3)
+    env = MultiAgentGridLifeEnv(config=config)
+    policy = EEAMultiAgentPolicy(
+        env, num_agents=config["multiagent"]["num_agents"], config=config
+    )
+
+    observations, _ = env.reset()
+    for idx, agent_id in enumerate(sorted(observations.keys())):
+        flat_obs = _flatten_obs(observations[agent_id])
+        action = policy.get_action(flat_obs, agent_id=idx)
+        assert action.shape == env.single_action_space.shape
+        assert np.all(action <= 1.0) and np.all(action >= -1.0)
+
+
+def test_eea_policy_rollout_runs_without_errors():
+    config = create_config(num_agents=2)
+    env = MultiAgentGridLifeEnv(config=config)
+    policy = EEAMultiAgentPolicy(
+        env, num_agents=config["multiagent"]["num_agents"], config=config
+    )
+
+    observations, _ = env.reset()
+    for _ in range(8):
+        actions = {}
+        for idx, agent_id in enumerate(list(observations.keys())):
+            flat_obs = _flatten_obs(observations[agent_id])
+            actions[agent_id] = policy.get_action(flat_obs, agent_id=idx)
+        observations, rewards, terminations, truncations, _ = env.step(actions)
+        assert set(actions.keys()).issubset(env.agents)
+        if terminations.get("__all__") or truncations.get("__all__"):
+            break

--- a/utils/factory.py
+++ b/utils/factory.py
@@ -9,6 +9,7 @@ from .validate_config import load_and_validate_config, validate_config
 from environments.grid_life import GridLifeEnv
 from environments.multi_agent_gridlife import MultiAgentGridLifeEnv
 from agents.persist_agent import PersistAgent
+from agents.eea_agent import EEAMultiAgentPolicy
 from agents.mpc_agent import MPCAgent
 from agents.shared_sac import SharedSAC
 from components.homeostat import Homeostat
@@ -485,6 +486,13 @@ class ComponentFactory:
                 role_embedding_dim=default_cfg['role_embedding_dim'],
                 config=self.config
             ).to(self.device)
+            policies['default'] = policy
+        elif default_cfg['policy'] == 'eea_agent':
+            policy = EEAMultiAgentPolicy(
+                env,
+                num_agents=self.config['multiagent']['num_agents'],
+                config=self.config
+            )
             policies['default'] = policy
         else:
             raise ValueError(f"Unsupported multi-agent policy type: {default_cfg['policy']}")


### PR DESCRIPTION
## Summary
- add an EEAMultiAgentPolicy that adapts the EEA scaffold into a heuristic multi-agent controller
- wire the factory to surface the new policy type and correct the multi-agent vision space shape
- add regression tests covering the heuristic policy action bounds and a short rollout

## Testing
- pytest
- mypy agents/ --ignore-missing-imports --follow-imports=skip

------
https://chatgpt.com/codex/tasks/task_e_68ec3713596c832cb23943cdb45def4a