### PR TITLE
Fix test imports for life stage manager

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+"""Test configuration ensuring project modules are importable when running individual files."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Pytest can execute a single test module directly (e.g. ``pytest tests/test_file.py``),
+# in which case the process working directory becomes ``tests/``. Ensure the repository
+# root is at the front of ``sys.path`` so package imports like ``components.*`` resolve
+# without manual path tweaks inside each test module.
+PROJECT_ROOT = str(Path(__file__).resolve().parents[1])
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)


### PR DESCRIPTION
## Summary
- ensure pytest adds the project root to sys.path when running individual test modules

## Testing
- pytest tests/test_life_stage_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68f2c9c91308832cb6c091fc90e263ab