### PR TITLE
Add stage-aware FireEvent recovery hooks for EEA++

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ After you make your selections, the final configuration will be displayed for co
 
 
 ### Progress Updates
+*   **2025-10-20T08:45:00-04:00**: Tightened stage-aware coordination between LifeStageManager and EEA agents.
+    *   Wired `ExperimentCoordinator` and `MultiAgentTrainer` to inject life-stage providers, telemetry hooks, and FireEvent listeners so stage transitions immediately retune affect buffers and entropy seeding.
+    *   Provisioned `LifeStageManager` for multi-agent builds so heuristic policies share developmental context with Prometheus metrics.
 *   **2025-10-19T22:02:14-04:00**: Ensured post-resource energy spikes still decay in multi-agent GridLife.
     *   Applied a fixed per-step decay after food consumption so agents cannot hover at max energy indefinitely, restoring attrition dynamics in long horizons.
 *   **2025-10-19T19:07:55-04:00**: Delivered stage-aware Emotional Equilibrium Atlas++ upgrades.

--- a/agents/eea_agent.py
+++ b/agents/eea_agent.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import logging
 from collections import deque
+from numbers import Integral
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import (
@@ -446,12 +447,16 @@ class EmotionalEquilibriumAgent:
         self._stage_memory: Dict[str, Deque[EmotionState]] = {}
         self._stage_memory_capacity = 64
         self._active_stage: Optional[StageContext] = None
+        self._fire_event_registered = False
 
     def configure_stage_awareness(
         self,
         *,
         stage_provider: Optional[StageProvider] = None,
         telemetry_hook: Optional[Callable[[Mapping[str, object]], None]] = None,
+        fire_event_register: Optional[
+            Callable[[Callable[[Mapping[str, object]], None]], None]
+        ] = None,
     ) -> None:
         """Attach runtime providers for life-stage awareness and telemetry."""
 
@@ -459,6 +464,44 @@ class EmotionalEquilibriumAgent:
             self._stage_provider = stage_provider
         if telemetry_hook is not None:
             self._telemetry_hook = telemetry_hook
+        if fire_event_register is not None and not self._fire_event_registered:
+            fire_event_register(self._handle_fire_event)
+            self._fire_event_registered = True
+
+    def _coerce_stage_context(
+        self, payload: Mapping[str, object] | StageContext | None
+    ) -> Optional[StageContext]:
+        if payload is None:
+            return None
+        if isinstance(payload, StageContext):
+            return payload
+
+        raw_targets = payload.get("affect_targets") or {}
+        targets: Dict[str, Tuple[float, float]] = {}
+        if isinstance(raw_targets, Mapping):
+            for key, bounds in raw_targets.items():
+                try:
+                    lower, upper = bounds  # type: ignore[misc]
+                except (TypeError, ValueError):
+                    continue
+                try:
+                    targets[str(key)] = (float(lower), float(upper))
+                except (TypeError, ValueError):
+                    continue
+
+        raw_name = payload.get("name")
+        name = str(raw_name) if raw_name is not None else "stage"
+        raw_index = payload.get("index")
+        index = -1
+        if isinstance(raw_index, Integral):
+            index = int(raw_index)
+        elif isinstance(raw_index, str):
+            try:
+                index = int(raw_index)
+            except ValueError:
+                index = -1
+
+        return StageContext(name=name, index=index, affect_targets=targets)
 
     def _resolve_stage_context(self) -> Optional[StageContext]:
         if self._stage_provider is None:
@@ -479,28 +522,7 @@ class EmotionalEquilibriumAgent:
                 "affect_targets": getattr(raw_context, "affect_targets", {}),
             }
 
-        raw_targets = payload.get("affect_targets") or {}
-        targets: Dict[str, Tuple[float, float]] = {}
-        if isinstance(raw_targets, Mapping):
-            for key, bounds in raw_targets.items():
-                try:
-                    lower, upper = bounds  # type: ignore[misc]
-                except (TypeError, ValueError):
-                    continue
-                try:
-                    targets[str(key)] = (float(lower), float(upper))
-                except (TypeError, ValueError):
-                    continue
-
-        raw_name = payload.get("name")
-        name = str(raw_name) if raw_name is not None else "stage"
-        raw_index = payload.get("index")
-        try:
-            index = int(raw_index) if raw_index is not None else -1
-        except (TypeError, ValueError):
-            index = -1
-
-        return StageContext(name=name, index=index, affect_targets=targets)
+        return self._coerce_stage_context(payload)
 
     def _handle_stage_transition(self, context: StageContext) -> None:
         ratio_bounds = context.affect_targets.get("ratio")
@@ -518,10 +540,15 @@ class EmotionalEquilibriumAgent:
                     _entropy_tolerance_from_ratio(ratio_bounds)
                 )
 
-        if context.name not in self._stage_memory:
-            self._stage_memory[context.name] = deque(maxlen=self._stage_memory_capacity)
+        self._seed_stage_buffers(context)
+        self._active_stage = context
 
-        experiences = list(self._stage_memory[context.name])
+    def _seed_stage_buffers(self, context: StageContext) -> None:
+        memory = self._stage_memory.setdefault(
+            context.name, deque(maxlen=self._stage_memory_capacity)
+        )
+        experiences = list(memory)
+        ratio_bounds = context.affect_targets.get("ratio")
         if ratio_bounds and experiences:
             midpoint = sum(ratio_bounds) * 0.5
             experiences.sort(key=lambda s: abs(s.ratio() - midpoint))
@@ -535,7 +562,24 @@ class EmotionalEquilibriumAgent:
                 self.meta.reset()
             self.modulation.entropy_buffer.reset()
 
-        self._active_stage = context
+    def _handle_fire_event(self, payload: Mapping[str, object]) -> None:
+        raw_context = payload.get("context")
+        context_payload = raw_context if isinstance(raw_context, Mapping) else {}
+
+        stage_hint: Mapping[str, object] | StageContext | None = None
+        if context_payload:
+            stage_hint = context_payload.get("stage") or context_payload.get(
+                "life_stage"
+            )
+
+        stage_context = self._coerce_stage_context(stage_hint)
+        if stage_context is not None:
+            self._handle_stage_transition(stage_context)
+            return
+
+        active = self._active_stage or self._resolve_stage_context()
+        if active is not None:
+            self._seed_stage_buffers(active)
 
     def _enforce_ratio_bounds(
         self, state: EmotionState, ratio_bounds: Tuple[float, float]

--- a/components/fire_event.py
+++ b/components/fire_event.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional
+from typing import Callable, List, Mapping, Optional
 
 import torch
 import torch.nn as nn
@@ -9,6 +9,7 @@ class FireEvent:
     """Utility for applying rapid plasticity changes after a fire trigger."""
 
     event_log = []
+    _listeners: List[Callable[[Mapping[str, object]], None]] = []
 
     @classmethod
     def apply(
@@ -16,6 +17,7 @@ class FireEvent:
         model: Optional[nn.Module],
         prune_fraction: float = 0.1,
         threshold_scale: float = 0.5,
+        context: Optional[Mapping[str, object]] = None,
     ) -> None:
         """Apply pruning and threshold mutation to the provided model."""
         if model is None:
@@ -25,12 +27,16 @@ class FireEvent:
         if not logger.handlers:
             handler = logging.StreamHandler()
             handler.setFormatter(
-                logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+                logging.Formatter(
+                    "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+                )
             )
             logger.addHandler(handler)
             logger.setLevel(logging.INFO)
 
-        logger.info("🔥 FireEvent triggered: compressing weights and lowering thresholds.")
+        logger.info(
+            "🔥 FireEvent triggered: compressing weights and lowering thresholds."
+        )
         cls._prune_weights(model, prune_fraction, logger)
         cls._mutate_thresholds(model, threshold_scale, logger)
 
@@ -39,11 +45,21 @@ class FireEvent:
                 "message": "FireEvent applied",
                 "prune_fraction": prune_fraction,
                 "threshold_scale": threshold_scale,
+                "context": dict(context) if isinstance(context, Mapping) else context,
             }
         )
 
+        payload = {
+            "prune_fraction": prune_fraction,
+            "threshold_scale": threshold_scale,
+            "context": dict(context) if isinstance(context, Mapping) else {},
+        }
+        cls._notify_listeners(payload)
+
     @staticmethod
-    def _prune_weights(model: nn.Module, prune_fraction: float, logger: logging.Logger) -> None:
+    def _prune_weights(
+        model: nn.Module, prune_fraction: float, logger: logging.Logger
+    ) -> None:
         if prune_fraction <= 0:
             return
 
@@ -93,3 +109,25 @@ class FireEvent:
     @classmethod
     def get_event_log(cls):
         return list(cls.event_log)
+
+    @classmethod
+    def register_listener(
+        cls, listener: Callable[[Mapping[str, object]], None]
+    ) -> None:
+        if listener not in cls._listeners:
+            cls._listeners.append(listener)
+
+    @classmethod
+    def clear_listeners(cls) -> None:
+        cls._listeners.clear()
+
+    @classmethod
+    def _notify_listeners(cls, payload: Mapping[str, object]) -> None:
+        if not cls._listeners:
+            return
+        for listener in list(cls._listeners):
+            try:
+                listener(payload)
+            except Exception as exc:  # pragma: no cover - listeners are best-effort
+                logger = logging.getLogger("FireEvent")
+                logger.debug("FireEvent listener error: %s", exc)

--- a/systems/coordinator.py
+++ b/systems/coordinator.py
@@ -1,3 +1,5 @@
+import inspect
+
 import torch
 import numpy as np
 
@@ -48,7 +50,60 @@ class ExperimentCoordinator:
         else:
             print("ℹ️ Curriculum disabled, using fixed parameters.")
 
+        self._configure_life_stage_observers()
+
         print("✅ Experiment Coordinator initialized.")
+
+    def _configure_life_stage_observers(self) -> None:
+        """Wire life-stage providers, telemetry, and fire events into agents."""
+
+        manager = getattr(self, "life_stage_manager", None)
+        telemetry = getattr(self, "telemetry_manager", None)
+
+        stage_provider = None
+        if manager is not None and hasattr(manager, "current_stage_summary"):
+            stage_provider = manager.current_stage_summary
+
+        telemetry_hook = None
+        if telemetry is not None and hasattr(telemetry, "update_life_stage"):
+            telemetry_hook = telemetry.update_life_stage
+
+        fire_event_register = None
+        if manager is not None:
+            fire_event_register = FireEvent.register_listener
+
+        def _configure_stage_target(target) -> None:
+            if target is None or not hasattr(target, "configure_stage_awareness"):
+                return
+
+            configure = getattr(target, "configure_stage_awareness")
+            try:
+                signature = inspect.signature(configure)
+            except (TypeError, ValueError):
+                signature = None
+
+            kwargs = {}
+            if signature is not None:
+                params = signature.parameters
+                if "stage_provider" in params and stage_provider is not None:
+                    kwargs["stage_provider"] = stage_provider
+                if "telemetry_hook" in params and telemetry_hook is not None:
+                    kwargs["telemetry_hook"] = telemetry_hook
+                if "fire_event_register" in params and fire_event_register is not None:
+                    kwargs["fire_event_register"] = fire_event_register
+
+            configure(**kwargs)
+
+        _configure_stage_target(getattr(self, "agent", None))
+
+        trainer = getattr(self, "trainer", None)
+        _configure_stage_target(trainer)
+
+        if trainer is not None:
+            policies = getattr(trainer, "policies", None)
+            if isinstance(policies, dict):
+                for policy in policies.values():
+                    _configure_stage_target(policy)
 
     def run(self):
         """

--- a/systems/coordinator.py
+++ b/systems/coordinator.py
@@ -142,7 +142,13 @@ class ExperimentCoordinator:
                     actor_model = getattr(self.agent, "actor", None)
                     if actor_model is None and hasattr(self.agent, "policy"):
                         actor_model = getattr(self.agent.policy, "actor", None)
-                    FireEvent.apply(actor_model)
+                    fire_context = {"reason": "environment_signal"}
+                    manager = getattr(self, "life_stage_manager", None)
+                    if manager is not None:
+                        summary = manager.current_stage_summary()
+                        if summary is not None:
+                            fire_context["stage"] = summary
+                    FireEvent.apply(actor_model, context=fire_context)
                     if self.continual_learning_manager and self.rehearsal_buffer:
                         self.continual_learning_manager.consolidate(
                             self.rehearsal_buffer
@@ -432,4 +438,8 @@ class ExperimentCoordinator:
         if actor_model is None and hasattr(self.agent, "policy"):
             actor_model = getattr(self.agent.policy, "actor", None)
         if actor_model is not None:
-            FireEvent.apply(actor_model)
+            fire_context = {"reason": "life_stage_transition"}
+            summary = manager.current_stage_summary()
+            if summary is not None:
+                fire_context["stage"] = summary
+            FireEvent.apply(actor_model, context=fire_context)

--- a/tests/test_eea_agent.py
+++ b/tests/test_eea_agent.py
@@ -1,7 +1,9 @@
 import numpy as np
 import pytest
+import torch.nn as nn
 
 from agents.eea_agent import ContextWeights, EmotionalEquilibriumAgent
+from components.fire_event import FireEvent
 from components.replay_buffer import ReplayBuffer
 
 
@@ -72,6 +74,38 @@ def test_stage_transition_reseeds_entropy_and_prior():
     expected_prior = sum(provider.stages[1]["affect_targets"]["ratio"]) / 2
     assert agent.meta.equilibrium_prior == pytest.approx(expected_prior, abs=0.01)
     assert agent.modulation.entropy_buffer.history, "History should be reseeded"
+
+
+def test_fire_event_recovery_reseeds_stage_memory():
+    FireEvent.clear_listeners()
+    provider = DummyStageProvider()
+    telemetry_payloads = []
+    agent = EmotionalEquilibriumAgent(stage_provider=provider)
+    agent.configure_stage_awareness(
+        stage_provider=provider,
+        telemetry_hook=telemetry_payloads.append,
+        fire_event_register=FireEvent.register_listener,
+    )
+    weights = ContextWeights(environmental=1.5, social=0.5, internal=0.25)
+
+    for _ in range(5):
+        agent.evaluate(0.65, 0.25, context_weights=weights)
+
+    agent.meta.equilibrium_prior = 0.2
+    stage_info = provider()
+
+    FireEvent.apply(
+        nn.Linear(1, 1, bias=False),
+        prune_fraction=0.0,
+        threshold_scale=1.0,
+        context={"reason": "unit_test", "stage": stage_info},
+    )
+
+    midpoint = sum(stage_info["affect_targets"]["ratio"]) / 2
+    assert agent.meta.equilibrium_prior == pytest.approx(midpoint, abs=0.01)
+    assert agent.modulation.entropy_buffer.history
+
+    FireEvent.clear_listeners()
 
 
 def test_replay_buffer_includes_stage_index():

--- a/utils/factory.py
+++ b/utils/factory.py
@@ -601,6 +601,7 @@ class ComponentFactory:
             cbf_coupler = self.create_cbf_coupler(env)
 
             telemetry_manager = self.create_telemetry_manager()
+            life_stage_manager = self.create_life_stage_manager()
 
             components = {
                 "env": env,
@@ -609,6 +610,7 @@ class ComponentFactory:
                 "resource_allocator": resource_allocator,
                 "cbf_coupler": cbf_coupler,
                 "telemetry_manager": telemetry_manager,
+                "life_stage_manager": life_stage_manager,
                 "device": self.device,
                 "config": self.config,
             }

--- a/utils/multi_agent_trainer.py
+++ b/utils/multi_agent_trainer.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import numpy as np
+import inspect
+
 import torch
 
 
@@ -25,6 +27,8 @@ class MultiAgentTrainer:
 
         # Assuming homogeneous agents for now, using one policy
         self.policy = self.policies["default"]
+
+        self._configure_stage_awareness()
 
         print("✅ MultiAgentTrainer initialized.")
 
@@ -146,6 +150,38 @@ class MultiAgentTrainer:
             print(
                 f"Episode {episode}: Length={ep_len}, TotalReward={ep_rew:.2f}, Steps={total_steps}"
             )
+
+    def _configure_stage_awareness(self) -> None:
+        manager = getattr(self, "life_stage_manager", None)
+        telemetry = getattr(self, "telemetry_manager", None)
+        if not isinstance(getattr(self, "policies", None), dict):
+            return
+
+        stage_provider = None
+        if manager is not None and hasattr(manager, "current_stage_summary"):
+            stage_provider = manager.current_stage_summary
+
+        telemetry_hook = None
+        if telemetry is not None and hasattr(telemetry, "update_life_stage"):
+            telemetry_hook = telemetry.update_life_stage
+
+        for policy in self.policies.values():
+            if not hasattr(policy, "configure_stage_awareness"):
+                continue
+
+            configure = getattr(policy, "configure_stage_awareness")
+            try:
+                params = inspect.signature(configure).parameters
+            except (TypeError, ValueError):
+                params = {}
+
+            kwargs = {}
+            if "stage_provider" in params and stage_provider is not None:
+                kwargs["stage_provider"] = stage_provider
+            if "telemetry_hook" in params and telemetry_hook is not None:
+                kwargs["telemetry_hook"] = telemetry_hook
+
+            configure(**kwargs)
 
     def _flatten_obs(self, obs_dict):
         """Flattens a dictionary observation into a single numpy array."""


### PR DESCRIPTION
## Summary
- teach the EmotionalEquilibriumAgent to register optional FireEvent listeners, coerce stage payloads, and reseed affect buffers from context-weighted memories
- expose listener registration on FireEvent and ensure coordinator fire events forward the active stage context
- extend the EEA agent tests to cover FireEvent-driven reseeding in addition to existing stage assertions

## Testing
- black .
- ruff check .
- mypy agents/
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f7a16370ac832ca040bf8d9db7b947