### PR TITLE
Refocus onboarding docs and move deep dives into dedicated guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,293 +1,81 @@
 # PERSIST
-A ml/ai framework for persistence. 
-Here’s a minimal-but-complete framework you can implement. It fuses (1) explicit homeostasis, (2) a viability kernel/shield, and (3) intrinsic persistence (empowerment or surprise minimization) on top of ordinary task reward.
----
-Philosophical Foundations
 
-This philosophy draws from several deep traditions:
+A persistence-first reinforcement learning stack that combines homeostatic control, safety shielding, and intrinsic drives so agents can stay viable while pursuing long-horizon goals.
 
-| Domain                     | Concept                         | Parallel in Persistence                                       |
-| -------------------------- | ------------------------------- | ------------------------------------------------------------- |
-| **Biology**                | Autopoiesis (Maturana & Varela) | Systems maintain themselves through internal regeneration     |
-| **Cybernetics**            | Homeostatic feedback loops      | Error correction as persistence strategy                      |
-| **Reinforcement Learning** | Reward ≈ survival signal        | Long-term viability replaces immediate reward                 |
-| **Thermodynamics**         | Entropy management              | Fire as controlled entropy reduction                          |
-| **Philosophy of Mind**     | Process ontology                | “Being” is replaced by “becoming” — existence is cyclical     |
-| **Mythology**              | Phoenix cycle                   | Destruction and rebirth as persistence through transformation |
+## Overview
+- **Purpose**: Provide a batteries-included reference implementation for persistence-centric research and experiments.
+- **What you get**: A guided CLI, modular safety and intrinsic-motivation components, and ready-to-run scenarios for single- and multi-agent studies.
+- **How to explore**: Start with the quickstart below, then jump into the configuration map to toggle the modules you need.
 
----
-## Getting Started
-
-This project includes an interactive command-line interface (CLI) to simplify running experiments.
-
-If you are designing training loops, see [`docs/training_resilience.md`](docs/training_resilience.md) for optimizer and LoRA adapter guidance tailored to PERSIST's fire-reset philosophy.
-
-For concrete, step-by-step examples of running the framework, follow the new [hands-on walkthroughs](docs/use_case_walkthroughs.md).
-
-### 1. Environment Setup
-
+## Quickstart
+### 1. Environment setup
 It is recommended to use Conda to manage dependencies.
 
-1.  **Create the Conda environment** from the `environment.yml` file:
-    ```bash
-    conda env create -f environment.yml
-    ```
-2.  **Activate the environment**:
-    ```bash
-    conda activate persist
-    ```
+1. **Create the Conda environment**
+   ```bash
+   conda env create -f environment.yml
+   ```
+2. **Activate the environment**
+   ```bash
+   conda activate persist
+   ```
 
-### 2. Running an Experiment
-
-Once the environment is activated, you can start the interactive CLI:
+### 2. Launch the guided CLI
+From the project root run:
 
 ```bash
 python main.py
 ```
 
-The CLI will guide you through several choices to configure your experiment:
-- **Standard single-agent experiment**: A basic setup, ideal for beginners.
-- **Multi-agent experiment**: A setup for running simulations with multiple agents.
-- **Robust agent experiment**: A setup that includes adversarial training and advanced safety features.
-- **Custom experiment**: Allows you to pick and choose features for a custom configuration.
-- **Run from `config.yaml`**: The original behavior, which runs the experiment directly from the `config.yaml` file without any modifications.
+The CLI walks through the standard single-agent build, optional multi-agent extensions, robustness toggles, and a "run from config" shortcut. You will see a confirmation card summarizing the final configuration before training starts.
 
-After you make your selections, the final configuration will be displayed for confirmation before the experiment begins.
+### 3. Continue learning
+- Follow the [hands-on walkthroughs](docs/use_case_walkthroughs.md) for baseline, multi-agent, and adversarial scenarios.
+- Review [training resilience tactics](docs/training_resilience.md) when designing custom learning loops.
 
+## Configuration map
+The `config.yaml` file wires every subsystem. Use the tables below to see where the implementations live and which knobs are considered core versus optional.
+
+### Core subsystems
+| Capability | Modules & docs | Location |
+| --- | --- | --- |
+| Homeostasis & viability | Homeostat, ViabilityApproximator, Safety Shield · [theory primer](docs/theory.md) | `components/`, `systems/`, `schemas/` |
+| Policy & training loop | PersistAgent, SAC/CTDE trainers, replay buffers | `agents/`, `utils/trainer.py`, `buffers/` |
+| World modelling & intrinsic drives | Latent/Dreamer world models, empowerment, surprise, RND | `components/latent_world_model.py`, `components/dreamer_world_model.py`, `components/empowerment.py`, `components/rnd.py` |
+| Configuration schema & validation | JSON/YAML schemas, CLI | `schemas/`, `config.yaml`, `main.py` |
+
+### Optional extensions
+| Capability | Modules & docs | Location |
+| --- | --- | --- |
+| Multi-agent coordination | Cooperative/competitive CTDE stack, Biodiversity Fabric Simulator · [deep dive](docs/multiagent.md) | `multiagent/`, `population/`, `environments/` |
+| Emotional Equilibrium Atlas++ | Affect-aware agents and life-stage choreography · [doc](docs/EEA.md) | `agents/eea_agent.py`, `population/`, `systems/` |
+| Growth-mimetic roadmap | Stage previews, lineage memory, biodiversity simulators · [technology brief](docs/growth_mimetic_technologies.md) | `evolution/`, `population/`, `docs/` |
+| Telemetry & operations | Prometheus telemetry, alerts, reporting | `ops/`, `utils/reporting.py` |
+| Robustness & adversaries | PGD adversary, safety probes, OOD detectors | `components/adversary.py`, `components/safety_probe.py`, `components/ood_detector.py` |
+| LoRA inference tooling | Adapter-aware model loader | `tools/lora_inference.py`, `tools/__init__.py` |
+
+## Key modules at a glance
+- **Experiment Coordinator** (`systems/coordinator.py`): orchestrates environments, agents, and persistence subsystems.
+- **ComponentFactory** (`utils/factory.py`): builds agents, shields, and optional modules from `config.yaml`.
+- **PersistenceManager** (`systems/persistence.py`): handles checkpointing, degraded-mode fallbacks, and restart flows.
+- **TelemetryManager** (`ops/telemetry.py`): exposes survival, constraint, and entropy metrics via Prometheus.
+- **Dreamer World Model** (`components/dreamer_world_model.py`): unlocks imagination rollouts for intrinsic planning.
+
+## Growth-mimetic roadmap
+The roadmap documents how growth-inspired systems land in the stack:
+- [docs/roadmap.md](docs/roadmap.md) for milestone tracking and verification plans.
+- [docs/growth_mimetic_devlog/](docs/growth_mimetic_devlog) for implementation notes.
+- [docs/growth_mimetic_technologies.md](docs/growth_mimetic_technologies.md) for vision statements and future modules.
+
+## Deep-dive references
+- [docs/theory.md](docs/theory.md): mathematical derivations, philosophical framing, and reward formulations.
+- [docs/multiagent.md](docs/multiagent.md): cooperative vs. competitive flows, BFS scenarios, and lineage tie-ins.
+- [docs/EEA.md](docs/EEA.md): affective agents and life-stage integrations.
+- [docs/summary.md](docs/summary.md): narrative overview of the persistence stack.
+- [docs/changelog.md](docs/changelog.md): full historical progress timeline.
 
 ### Progress Updates
-*   **2025-10-27T09:45:00+00:00**: Added an agent integration smoke suite.
-    *   Published `python -m agents.tests.integration_check` so contributors can run curated persistence, EEA, and multi-agent checks without hunting for the right pytest targets.
-    *   Ensured the module loads under the documented namespace, keeping pre-commit guidance in sync with the repository layout.
-*   **2025-10-27T02:15:00+00:00**: Hardened lineage utilities for multi-agent runs.
-    *   Gated coordinator lineage blending and fire events when no single-agent controller is present so ComponentFactory multi-agent experiments avoid startup crashes.
-    *   Taught checkpointing and affect export hooks to skip gracefully without a standalone agent, keeping lineage archival and recovery compatible across trainers.
-*   **2025-10-26T15:45:00+00:00**: Restored baseline configurations after the lineage rollout.
-    *   Added a default biodiversity archetype and CLI translation guardrails so smoke tests and lightweight configs can run the multi-agent simulator without bespoke species files.
-    *   Ensured automated suites can mock `config.yaml` loads again, keeping the interactive CLI and regression coverage stable for contributors.
-*   **2025-10-26T09:30:00+00:00**: Implemented the Transgenerational Memory Weave lineage stack.
-    *   Added lineage archiving, Fisher-masked blending, and respawn initialization so new agents inherit policy, viability, and safety priors across stages.
-    *   Introduced lineage-aware CLI reporting, configuration knobs, and documentation so experimenters can audit and tune cross-generational memory.
-*   **2025-10-25T18:00:00+00:00**: Documented an implementation timeline across roadmap and pitch materials.
-    *   Annotated `docs/summary.md`, `docs/roadmap.md`, `docs/growth_mimetic_technologies.md`, and `docs/roadmap102125.md` with commit-stamped checkpoints so contributors can see which growth-mimetic features already landed and what remains.
-    *   Clarified that the CLI renders life-stage previews automatically (no `--preview-growth` flag) and highlighted outstanding telemetry storytelling work for EEA++.
-*   **2025-10-25T12:00:00+00:00**: Expanded the UI/UX improvement backlog with navigation, celebration, and dashboard starter ideas.
-    *   Enriched `docs/ui_ux_improvements.md` with rewindable CLI controls, milestone callouts, Prometheus dashboard kits, and onboarding visuals so experience workstreams have actionable next steps.
-*   **2025-10-24T09:15:00+00:00**: Refined the UI/UX improvements backlog around guidance-first enhancements.
-    *   Captured adaptive navigation, run-time visualization, telemetry dashboards, onboarding overlays, and accessibility controls in `docs/ui_ux_improvements.md` to steer the next iteration of experience work.
-*   **2025-10-23T14:32:00+00:00**: Expanded UI/UX roadmap with replay, collaboration, and ops-aligned ideas.
-    *   Added narrative tooling, persona-driven flows, and operations integrations to `docs/ui_ux_improvements.md` so design and engineering teams can prioritize richer telemetry storytelling and handoff experiences.
-*   **2025-10-22T00:12:23+00:00**: Delivered the Biodiversity Fabric Simulator milestone.
-    *   Landed species archetype schemas, succession knobs, and telemetry wiring so BFS scenarios can be configured from the CLI and config files.
-    *   Upgraded multi-agent environments, population shielding, and Prometheus gauges to track richness, trophic stability, and mutualism dynamics.
-    *   Documented BFS workflows, configuration tips, and added a smoke test to keep multi-species runs stable.
-*   **2025-10-20T08:45:00-04:00**: Tightened stage-aware coordination between LifeStageManager and EEA agents.
-    *   Wired `ExperimentCoordinator` and `MultiAgentTrainer` to inject life-stage providers, telemetry hooks, and FireEvent listeners so stage transitions immediately retune affect buffers and entropy seeding.
-    *   Provisioned `LifeStageManager` for multi-agent builds so heuristic policies share developmental context with Prometheus metrics.
-*   **2025-10-19T22:02:14-04:00**: Ensured post-resource energy spikes still decay in multi-agent GridLife.
-    *   Applied a fixed per-step decay after food consumption so agents cannot hover at max energy indefinitely, restoring attrition dynamics in long horizons.
-*   **2025-10-19T19:07:55-04:00**: Delivered stage-aware Emotional Equilibrium Atlas++ upgrades.
-    *   Taught `EmotionalEquilibriumAgent` to pull life-stage targets, reseed entropy buffers, emit telemetry payloads, and share providers with the heuristic multi-agent policy.
-    *   Threaded `life_stage_index` through replay buffers, trainers, and coordinator telemetry so developmental context travels with every stored experience and Prometheus gauge.
-    *   Added focused tests to lock stage-bound ratio enforcement, transition reseeding, and LifeStageManager progressions.
-*   **2025-10-18T15:52:43-04:00**: Added a Dreamer-style latent world model with imagination rollouts.
-    *   Implemented an RSSM backbone, rollout API, and Dreamer-specific optimizers plus regression tests covering KL math and viability rollouts.
-    *   Wired factory/trainer hooks so `world_model.type: "dreamer"` toggles the new module, updates intrinsic reward flows, and exposes enablement steps in docs and walkthroughs.
-*   **2025-10-18T11:18:51-04:00**: Captured Growth-Mimetic roadmap status and filed implementation issues.
-    *   Authored a technology pitch summarizing stage dynamics, biodiversity simulators, and lineage memory plans with milestone checklists.
-    *   Opened detailed issue briefs for the Dreamer upgrade, EEA++, biodiversity fabric, and transgenerational memory weave initiatives.
-*   **2025-10-16T19:15:05-04:00**: Introduced life-stage management scaffolding and telemetry visibility.
-    *   Created `LifeStageManager` to parse viability schemas, emit stage metrics, and preview timelines in the CLI walkthrough.
-    *   Expanded Prometheus gauges to report stage index, progress, affect bands, and transition counters for dashboarding.
-*   **2025-10-13T09:00:20-04:00**: Added a heuristic multi-agent controller driven by the EEA scaffold.
-    *   Built `EEAMultiAgentPolicy` with observation splitting, behavior-conditioned movement heuristics, and deterministic seeding for reproducible swarm runs.
-    *   Extended replay tests to confirm stage indices propagate alongside joint transitions.
-*   **2025-10-04T09:02:05-04:00**: Implemented a Genetic Algorithm (GA) engine for meta-optimization.
-    *   Added a new `evolution` module containing a generic GA/ES engine, NSGA-II selection, and operators for mutation and crossover.
-    *   Integrated the GA engine into the main CLI, allowing users to run GA-based experiments to optimize hyperparameters.
-    *   Included a new test suite for the GA core to ensure its functionality.
-*   **2025-09-30T09:10:05-04:00**: Hardened the LoRA inference utilities for transformer workflows.
-    *   Extended `LoRAInferencePipeline` so tokenizer initialization kwargs stay separate from per-call arguments while exposing an override for generation-time parameters.
-    *   Added guard rails and pytest skips around optional `peft` dependencies alongside a regression test that asserts tokenizer configuration is respected end-to-end.
-*   **2025-09-30T09:05:30-04:00**: Introduced a LoRA-aware inference pipeline with comprehensive coverage.
-    *   Implemented `tools/lora_inference.py` and `tools/__init__.py` to assemble base backbones with one or many adapters, optionally merging them before evaluation.
-    *   Added targeted tests (`tests/test_lora_inference.py`) that fabricate lightweight adapters to validate merge semantics, adapter naming, and callable behavior.
-    *   Declared `peft` and `transformers` dependencies to support Hugging Face model loading within the new tooling.
-*   **2025-09-29T22:16:25-04:00**: Published end-to-end walkthroughs for typical persistence experiments.
-    *   Authored `docs/use_case_walkthroughs.md` with guided exercises for baseline, multi-agent, and adversarial training runs, connecting CLI prompts to telemetry and testing artifacts.
-    *   Expanded `docs/ui_ux_improvements.md` with beginner-centric onboarding concepts like guided tours, template libraries, and interactive glossaries.
-    *   Linked the README to the walkthroughs so newcomers can navigate from setup instructions to practical scenarios.
-*   **2025-09-29T22:01:16-04:00**: Documented optimizer and adapter tactics for resilient training.
-    *   Created `docs/training_resilience.md` outlining persistence-friendly optimizers plus LoRA and PEFT strategies aligned with the fire-reset philosophy.
-    *   Highlighted the new guide in the README to steer training loop designers toward recovery-aware tooling.
-*   **2025-09-29T11:51:24-04:00**: Elevated the CLI walkthrough with visual progress cues and summaries.
-    *   Introduced a `StepProgressTracker`, Rich-powered panels, and confirmation cards in `main.py` so users can see step counts, validated inputs, and consolidated selections.
-    *   Tweaked numeric prompts to echo accepted values and ensured the walkthrough culminates in a top-level configuration digest.
-    *   Added `rich` to the dependency list to support the upgraded console rendering.
-*   **2025-09-29T11:34:13-04:00**: Captured UI/UX progression opportunities in dedicated documentation.
-    *   Authored `docs/ui_ux_improvements.md` to catalog CLI enhancements, training visuals, telemetry dashboards, onboarding aids, and accessibility options.
-    *   Emphasized progress indicators, celebratory milestones, and documentation touchpoints to keep contributors aligned on experiential goals.
-*   **2025-09-29T10:35:25-04:00**: Captured the long-term roadmap and review guidance in dedicated documentation.
-    *   Authored `docs/roadmap.md` to record wins, refactor priorities, testing plans, and milestone checklists for future contributors.
-    *   Documented actionable steps for README modularization, API hygiene, CI coverage, and developer experience improvements.
-    *   Highlighted near-term verification, collaboration, and benchmarking tasks to keep the repository aligned with the architecture vision.
-*   **2025-09-29T10:34:54-04:00**: Streamlined the top-level README around quick start usage.
-    *   Removed internal review checklists so the README now emphasizes onboarding instructions and the progress journal.
-    *   Focused the "Getting Started" narrative on the Conda workflow and interactive CLI entry point for running experiments.
-    *   Preserved the historical changelog while paving the way for deeper docs to live in `docs/`.
-*   **2025-09-29T10:32:17-04:00**: Deepened the CLI walkthrough for configuring training runs.
-    *   Added interactive flows in `main.py` that let users tune epochs, update cadence, learning rates, and shield amortization thresholds before launching training.
-    *   Enabled optional prompts for resizing network capacity and curriculum schedules, keeping advanced knobs accessible without editing YAML by hand.
-    *   Synced defaults in `config.yaml` with the new questionnaire so saved configurations match the guided selections.
-*   **2025-09-28T10:02:12+00:00**: Added automated data collection around the viability frontier.
-    *   Implemented a configurable `NearBoundaryBuffer` (`buffers/near_boundary.py`) that captures internal states with safety
-        probabilities near the decision boundary and replays them during updates.
-    *   Extended the trainer and coordinator so the `ViabilityApproximator` (and ensemble variants) receive extra supervision
-        on these ambiguous samples, improving shield accuracy without inducing extra risk.
-    *   Updated `config.yaml` and the viability schema to expose `viability.near_boundary_buffer` controls and documented the
-        feature in `docs/theory.md`.
-    *   Added targeted unit tests for the buffer to guarantee sampling and filtering behave as expected.
-*   **2025-09-28T09:14:00+00:00**: Improved developer experience by simplifying setup and usage.
-    *   Added an `environment.yml` file to allow for easy environment setup using Conda.
-    *   Created a "Getting Started" section in `README.md` to document the environment setup process and the existing interactive CLI.
-*   **2025-09-28T08:44:41+00:00**: Implemented an interactive command-line interface (CLI) in `main.py`.
-    *   The new CLI guides users through selecting an experiment type (e.g., standard single-agent, multi-agent, robust agent) or building a custom configuration.
-    *   This eliminates the need for manual `config.yaml` editing for most use cases, making the framework more user-friendly.
-    *   The underlying `ComponentFactory` and validation logic were refactored to support dynamic configuration generation.
-*   **2025-09-28T07:48:00+00:00**: Improved framework robustness and observability.
-    *   Strengthened the testing framework by adding comprehensive test suites for the multi-agent environment (`tests/test_multiagent_env.py`) and the safety shield (`tests/test_shield.py`).
-    *   Implemented a fail-fast configuration validation system by creating a master JSON schema (`schemas/config.schema.json`) and integrating it into the application's startup sequence.
-    *   Added detailed logging to the `Shield` and `ResourceAllocator` components to provide debug traces for safety and resource management decisions.
-*   **2025-09-28T05:07:24+00:00**: Completed major framework components and documentation alignment.
-    *   Replaced the mock Hamilton-Jacobi reachability analysis with a functional, grid-based backward reachability implementation in `tools/hj_reachability/compute_viability.py`.
-    *   Expanded the constraint governance feature by updating `schemas/viability.schema.json` to a more detailed, structured format and modified `config.yaml` and `environments/grid_life.py` to use the new schema.
-    *   Refactored the self-maintenance logic into a dedicated `MaintenanceManager` class in `environments/maintenance_tasks.py` for improved modularity.
-    *   Updated the `README.md` to accurately reflect the current state of the project, including removing outdated sections and updating configuration examples.
-*   **2025-09-27T18:49:00+00:00**: Implemented the "Governance + telemetry" feature.
-    *   Created an `ops/` directory for operational components.
-    *   Added a `TelemetryManager` (`ops/telemetry.py`) that uses `prometheus-client` to expose key training metrics (e.g., survival time, constraint violations, shield trigger rate) via an HTTP endpoint.
-    *   Defined a set of sample alerting rules in `ops/alerts.yml` for use with a Prometheus server.
-    *   Integrated the `TelemetryManager` into the main training loop (`systems/coordinator.py` and `utils/trainer.py`) to provide real-time monitoring of the agent's performance and stability.
-    *   Added a `telemetry` section to `config.yaml` to enable and configure the feature.
-*   **2025-09-27T15:19:51+00:00**: Implemented a multi-agent persistence architecture (CTDE).
-    *   Created `MultiAgentGridLifeEnv` with a dictionary-based API for managing multiple agents in a shared world.
-    *   Implemented a `SharedSAC` agent using parameter sharing and role embeddings for efficient homogeneous multi-agent learning.
-    *   Added a `MultiAgentTrainer` and `ReplayMA` buffer to handle the centralized training loop.
-    *   Integrated a `ResourceAllocator` for proportional resource distribution and a `CBFCoupler` for collision avoidance.
-    *   The entire multi-agent system is configurable via the `multiagent` and `agent_types` sections in `config.yaml`.
-*   **2025-09-27T13:32:29+00:00**: Implemented interpretability for the safety path.
-    *   Added a `SafetyProbe` component (`components/safety_probe.py`) to predict individual constraint margins, providing insight into the agent's safety status.
-    *   Created a `SafetyReporter` (`utils/reporting.py`) to generate detailed JSON logs explaining why the safety shield modified an action.
-    *   The environment now calculates and provides true constraint margins, which are used to train the probe.
-    *   The feature is fully configurable via the `safety_probe` section in `config.yaml`.
-*   **2025-09-27T13:29:35+00:00**: Implemented adversarial robustness.
-    *   Added an `Adversary` component (`components/adversary.py`) that uses PGD to generate adversarial examples.
-    *   Created a `RobustTrainer` (`utils/robust_trainer.py`) to handle adversarial training.
-    *   The `SAC` agent's critic is now trained on these adversarial examples to improve robustness.
-    *   The feature is configurable via the `adversarial` section in `config.yaml`.
-*   **2025-09-27T13:13:49+00:00**: Implemented self-maintenance behaviors.
-    *   Added "refuel," "cool-down," and "repair" stations to the `GridLifeEnv`.
-    *   These tasks incur a small configurable penalty, encouraging the agent to learn strategic resource management.
-    *   Updated `config.yaml` with a `maintenance` section to control these features.
-*   **2025-09-27T13:07:11+00:00**: Implemented the Hamilton-Jacobi (HJ) Reachability analysis scaffolding.
-    *   Created `tools/hj_reachability/compute_viability.py` as a placeholder for offline viable set computation.
-    *   Added `scripts/distill_viability.py` to train the `ViabilityApproximator` by distilling knowledge from the pre-computed set.
-    *   This establishes the workflow for using formal methods to define safety and then transferring that knowledge to a neural network.
-*   **2025-09-27T12:40:00+00:00**: Implemented the "Resource Accounting / Bounded Rationality" feature.
-    *   Created a `BudgetMeter` component (`components/budget_meter.py`) to track resource consumption (e.g., energy, computation time) over an episode.
-    *   Integrated the `BudgetMeter` into the main training loop (`utils/trainer.py`), which now terminates an episode and applies a configurable penalty if the agent's budget is exhausted.
-    *   Added a `budgets` section to `config.yaml` to allow enabling and configuring this feature.
-*   **2025-09-27T12:25:30+00:00**: Implemented several key system-level features to enhance robustness and verifiability.
-    *   Added a `PersistenceManager` (`systems/persistence.py`) for atomic checkpointing and a `DegradedModePolicy` (`policies/degraded_mode.py`) for safe fallbacks.
-    *   Established a verification harness with property-based safety tests (`tests/spec_safety_test.py`) and a scenario fuzzer (`tools/fuzz_scenarios.py`).
-    *   Created an evaluation suite (`benchmarks/persist_suite/`) with scenarios for regime shifts like sensor dropout, dynamics drift, and rare hazards.
-    *   Implemented a data contract (`schemas/viability.schema.json`) and a validation script (`utils/validate_config.py`) to ensure configuration integrity.
-*   **2025-09-27T19:16:45+00:00**: Implemented the "Population-level persistence" extension by adding an `EnsembleShield`.
-    *   Created a `population/` directory to house all population-based components.
-    *   Implemented the `EnsembleShield` (`population/ensemble_shield.py`), which aggregates safety votes from multiple `ViabilityApproximator` models.
-    *   The `EnsembleShield` supports multiple voting mechanisms, such as "veto_if_any_unsafe" and "majority_vote."
-    *   Updated the `ComponentFactory` and `config.yaml` to allow for the creation and configuration of the `EnsembleShield`.
-    *   Modified the `Trainer` to train all models in the `viability_ensemble`.
-*   **2025-09-27T12:07:30+00:00**: Implemented a continual learning system to mitigate catastrophic forgetting.
-    *   Created a `RehearsalBuffer` (`buffers/rehearsal.py`) to store past experiences using reservoir sampling.
-    *   Implemented a `ContinualLearningManager` (`components/continual.py`) that uses Elastic Weight Consolidation (EWC) to protect important neural network weights.
-    *   Integrated the EWC penalty into the SAC agent's loss function and added a periodic consolidation step to the main training loop.
-*   **2025-09-27T18:00:00+00:00**: Implemented advanced safety and robustness features as outlined in the roadmap.
-    *   Added a Control Barrier Function (CBF) layer (`components/cbf_layer.py`) to provide formal safety guarantees by solving a Quadratic Program to filter actions. This includes a `DynamicsAdapter` (`components/dynamics_adapter.py`) for linearizing the internal model.
-    *   Implemented a `ConstraintManager` (`components/constraint_manager.py`) that uses dual ascent to automatically tune homeostatic penalty multipliers, enforcing a target violation rate without manual parameter tuning.
-    *   Introduced an energy-based Out-of-Distribution (OOD) detector (`components/ood_detector.py`) to identify novel states and a `SafeFallbackPolicy` (`policies/safe_fallback.py`) to ensure the agent takes a safe action when encountering them.
-*   **2025-09-27T17:31:45+00:00**: Refactored the codebase for improved modularity, maintainability, and performance.
-    *   Introduced a `ComponentFactory` (`utils/factory.py`) to centralize the initialization of all framework components.
-    *   Created a `Trainer` class (`utils/trainer.py`) to encapsulate the main training loop and update logic, simplifying `train.py`.
-    *   Added device management for GPU acceleration, automatically moving models and tensors to a CUDA device if available.
-    *   Optimized the data pipeline by modifying the `ReplayBuffer` to return tensors directly on the correct device, reducing overhead.
-*   **2025-09-27T16:44:07+00:00**: Established a testing framework and added unit tests for core components.
-    *   Created a `tests/` directory to house all test suites.
-    *   Added `tests/test_components.py` with unit tests for `Homeostat`, `ViabilityApproximator`, and `InternalModel`.
-    *   These tests verify the correctness of reward calculation, model training, and prediction logic, improving the project's robustness and maintainability.
-*   **2025-09-27T08:11:30+00:00**: Implemented a comprehensive evaluation and metrics logging system.
-    *   Created an `Evaluator` class in `utils/evaluation.py` to handle logging.
-    *   The system now tracks and logs key metrics from the `README.md` file, including survival time, constraint satisfaction rates, and policy entropy.
-    *   Metrics are saved to `training.log` in a structured JSON format for analysis.
-    *   The main training loop in `train.py` was updated to integrate the evaluator.
-*   **2025-09-27T07:22:55+00:00**: Implemented the "Reach-avoid MPC" extension.
-    *   Created a `ReachAvoidMPC` component (`components/reach_avoid_mpc.py`) that uses model-predictive control to plan safe, goal-oriented actions.
-    *   The MPC planner uses the `LatentWorldModel`, `InternalModel`, and `ViabilityApproximator` to simulate future trajectories and select the best action sequence via the Cross-Entropy Method (CEM).
-    *   Created a new `MPCAgent` (`agents/mpc_agent.py`) to integrate the planner into the training loop.
-    *   Added an `mpc` section to `config.yaml` to enable and configure the MPC agent.
-*   **2025-09-27T14:08:18+00:00**: Implemented the "Risk-sensitive RL" extension.
-    *   Created a `CVAR_SAC` agent (`agents/cvar_sac.py`) that optimizes the Conditional Value at Risk (CVaR) of the return distribution, making the agent risk-averse.
-    *   Implemented a `DistributionalCritic` that learns the return distribution using quantile regression.
-    *   The actor's objective is to maximize the CVaR of the critic's predicted distribution.
-    *   The feature is configurable in `config.yaml` via the `risk_sensitive` section, allowing control over risk-aversion.
-*   **2025-09-27T13:59:05+00:00**: Implemented the "Adaptive setpoints" extension.
-    *   Created a `MetaLearner` component (`components/meta_learner.py`) to dynamically adjust homeostatic setpoints (`mu`) based on long-term performance.
-    *   Integrated the `MetaLearner` into the main training loop (`train.py`), allowing the agent to adapt its internal targets.
-    *   Added a `meta_learning` section to `config.yaml` to control this feature.
-*   **2025-09-27T06:09:46+00:00**: Implemented the 'Empowerment' intrinsic reward module as described in the framework's core concepts.
-    *   Created a new `Empowerment` component (`components/empowerment.py`) that uses a contrastive discriminator (InfoNCE) to calculate intrinsic rewards.
-    *   The component is trained on-the-fly using rollouts from the `LatentWorldModel`.
-    *   Updated `train.py` to support 'empowerment' as a configurable intrinsic reward method.
-    *   Added an `empowerment` section to `config.yaml` for hyperparameters.
-*   **2025-09-26 12:23:24.130399**: Completed Phase 2 of the implementation plan by integrating a surprise-based intrinsic reward.
-    *   Created a `WorldModel` component (`components/world_model.py`) using PyTorch to predict the next observation.
-    *   The prediction error (MSE) of the `WorldModel` is used as the surprise reward (`r_intr`).
-    *   The main training loop (`train.py`) was updated to initialize and train the `WorldModel`.
-    *   The total reward was updated to `r_total = r_task + lambda_H * r_homeo + lambda_I * r_intr`.
-    *   Added `torch` and `pyyaml` to `requirements.txt`.
-*   **2025-09-26 14:54:16.787780**: Completed Phase 3 of the implementation plan by integrating the Viability Shield.
-    *   Created an `InternalModel` (`components/internal_model.py`) to predict the next internal state.
-    *   Created a `ViabilityApproximator` (`components/viability_approximator.py`) to predict the safety of a state.
-    *   Created a `Shield` (`components/shield.py`) to filter unsafe actions.
-    *   Updated the `ReplayBuffer` to store internal states and viability labels.
-    *   Integrated all new components into the main training loop (`train.py`), which now uses the shield to select safe actions and trains the new models.
-*   **2025-09-26 15:17:41.792207**: Implemented "Change 2" from the modernization plan by replacing the surprise-based intrinsic reward with Random Network Distillation (RND).
-    *   Created an `RND` component (`components/rnd.py`) that calculates intrinsic reward based on the prediction error of a randomly initialized target network.
-    *   Updated the main training loop (`train.py`) to use the `RND` component for intrinsic motivation.
-    *   Modified `config.yaml` to allow selecting `"rnd"` as the intrinsic reward type.
-*   **2025-09-26 18:18:45.834302**: Implemented "Change 3" from the modernization plan by amortizing the Safety Shield's computation.
-    *   Created a `SafetyNetwork` component (`components/safety_network.py`) that learns to project unsafe actions to safe ones.
-    *   Updated the `ReplayBuffer` to store both unsafe and safe actions to create a training dataset for the `SafetyNetwork`.
-    *   Modified the `Shield` to operate in two modes: a `search` mode for data collection and an `amortized` mode that uses the trained `SafetyNetwork` for fast projection.
-    *   Updated the main training loop (`train.py`) to train the `SafetyNetwork` and switch the shield's mode after a configured number of steps.
-    *   Added a `safety_network` section to `config.yaml` to control the new component's hyperparameters.
-*   **2025-09-26 18:52:38.574183**: Implemented "Change 1" from the modernization plan by replacing the simple world model with a latent dynamics model.
-    *   Created a `LatentWorldModel` (`components/latent_world_model.py`) with separate `Encoder`, `TransitionModel`, and `Decoder` modules.
-    *   The model is trained on reconstruction and dynamics prediction losses.
-    *   The intrinsic reward is now calculated as the reconstruction error from the predicted latent state, providing a more robust surprise signal.
-    *   Updated `train.py` to use the new latent model and switched `config.yaml` to use `"surprise"` reward.
-*   **2025-09-26 19:15:19.784624**: Implemented "Change 4" from the modernization plan by enabling the `ViabilityApproximator` to learn from safe demonstrations.
-    *   Created a `DemonstrationBuffer` (`components/demonstration_buffer.py`) to load and sample expert data.
-    *   Modified the `ViabilityApproximator` to include a `train_on_demonstrations` method, allowing it to pre-train on safe states.
-    *   Updated the main training loop (`train.py`) to use the new buffer and training method.
-    *   Added a `demonstrations` section to `config.yaml` to specify the data path.
-*   **2025-09-26 20:20:23.540386**: Implemented curriculum learning as described in the "Implementation order."
-    *   Added a `CurriculumScheduler` to `train.py` to gradually increase the weights of persistence rewards (`lambda_homeo`, `lambda_intr`) and tighten the environment's viability constraints over a configurable number of steps.
-    *   The `GridLifeEnv` was updated to support dynamic constraint changes.
-    *   Added a `curriculum` section to `config.yaml` to control the new scheduling feature.
-*   **2025-09-26 20:49:35.720744**: Implemented the "Partial Observability" extension from the roadmap.
-    *   Created a `StateEstimator` component (`components/state_estimator.py`) with a GRU network to predict the internal state from external observations.
-    *   Modified the `GridLifeEnv` to optionally hide the true internal state, simulating partial observability.
-    *   Updated `train.py` to use the `StateEstimator` when partial observability is enabled, feeding the estimated state to the agent and other components.
-    *   Enhanced the `ReplayBuffer` to support sampling of contiguous sequences required for training the recurrent estimator.
-    *   Added `state_estimator` and `partial_observability` configurations to `config.yaml`.
+* **2025-10-27T16:30:00+00:00**: Modularized onboarding docs and relocated deep dives.
+  * Rebuilt the README around overview, quickstart, and configuration maps so newcomers can stand up experiments without sifting through theoretical derivations.
+  * Added `docs/changelog.md` for the full progress journal and `docs/multiagent.md` for cooperative/competitive walkthroughs, keeping deep content a click away while preserving navigability.
+* _Earlier updates now live in [docs/changelog.md](docs/changelog.md)._ 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,241 @@
+# PERSIST Changelog
+
+This file centralizes the historical progress updates that used to live in `README.md`. Each entry records what shipped and why it matters for practitioners.
+
+## Progress Timeline
+
+*   **2025-10-27T09:45:00+00:00**: Added an agent integration smoke suite.
+    *   Published `python -m agents.tests.integration_check` so contributors can run curated persistence, EEA, and multi-agent checks without hunting for the right pytest targets.
+    *   Ensured the module loads under the documented namespace, keeping pre-commit guidance in sync with the repository layout.
+*   **2025-10-27T02:15:00+00:00**: Hardened lineage utilities for multi-agent runs.
+    *   Gated coordinator lineage blending and fire events when no single-agent controller is present so ComponentFactory multi-agent experiments avoid startup crashes.
+    *   Taught checkpointing and affect export hooks to skip gracefully without a standalone agent, keeping lineage archival and recovery compatible across trainers.
+*   **2025-10-26T15:45:00+00:00**: Restored baseline configurations after the lineage rollout.
+    *   Added a default biodiversity archetype and CLI translation guardrails so smoke tests and lightweight configs can run the multi-agent simulator without bespoke species files.
+    *   Ensured automated suites can mock `config.yaml` loads again, keeping the interactive CLI and regression coverage stable for contributors.
+*   **2025-10-26T09:30:00+00:00**: Implemented the Transgenerational Memory Weave lineage stack.
+    *   Added lineage archiving, Fisher-masked blending, and respawn initialization so new agents inherit policy, viability, and safety priors across stages.
+    *   Introduced lineage-aware CLI reporting, configuration knobs, and documentation so experimenters can audit and tune cross-generational memory.
+*   **2025-10-25T18:00:00+00:00**: Documented an implementation timeline across roadmap and pitch materials.
+    *   Annotated `docs/summary.md`, `docs/roadmap.md`, `docs/growth_mimetic_technologies.md`, and `docs/roadmap102125.md` with commit-stamped checkpoints so contributors can see which growth-mimetic features already landed and what remains.
+    *   Clarified that the CLI renders life-stage previews automatically (no `--preview-growth` flag) and highlighted outstanding telemetry storytelling work for EEA++.
+*   **2025-10-25T12:00:00+00:00**: Expanded the UI/UX improvement backlog with navigation, celebration, and dashboard starter ideas.
+    *   Enriched `docs/ui_ux_improvements.md` with rewindable CLI controls, milestone callouts, Prometheus dashboard kits, and onboarding visuals so experience workstreams have actionable next steps.
+*   **2025-10-24T09:15:00+00:00**: Refined the UI/UX improvements backlog around guidance-first enhancements.
+    *   Captured adaptive navigation, run-time visualization, telemetry dashboards, onboarding overlays, and accessibility controls in `docs/ui_ux_improvements.md` to steer the next iteration of experience work.
+*   **2025-10-23T14:32:00+00:00**: Expanded UI/UX roadmap with replay, collaboration, and ops-aligned ideas.
+    *   Added narrative tooling, persona-driven flows, and operations integrations to `docs/ui_ux_improvements.md` so design and engineering teams can prioritize richer telemetry storytelling and handoff experiences.
+*   **2025-10-22T00:12:23+00:00**: Delivered the Biodiversity Fabric Simulator milestone.
+    *   Landed species archetype schemas, succession knobs, and telemetry wiring so BFS scenarios can be configured from the CLI and config files.
+    *   Upgraded multi-agent environments, population shielding, and Prometheus gauges to track richness, trophic stability, and mutualism dynamics.
+    *   Documented BFS workflows, configuration tips, and added a smoke test to keep multi-species runs stable.
+*   **2025-10-20T08:45:00-04:00**: Tightened stage-aware coordination between LifeStageManager and EEA agents.
+    *   Wired `ExperimentCoordinator` and `MultiAgentTrainer` to inject life-stage providers, telemetry hooks, and FireEvent listeners so stage transitions immediately retune affect buffers and entropy seeding.
+    *   Provisioned `LifeStageManager` for multi-agent builds so heuristic policies share developmental context with Prometheus metrics.
+*   **2025-10-19T22:02:14-04:00**: Ensured post-resource energy spikes still decay in multi-agent GridLife.
+    *   Applied a fixed per-step decay after food consumption so agents cannot hover at max energy indefinitely, restoring attrition dynamics in long horizons.
+*   **2025-10-19T19:07:55-04:00**: Delivered stage-aware Emotional Equilibrium Atlas++ upgrades.
+    *   Taught `EmotionalEquilibriumAgent` to pull life-stage targets, reseed entropy buffers, emit telemetry payloads, and share providers with the heuristic multi-agent policy.
+    *   Threaded `life_stage_index` through replay buffers, trainers, and coordinator telemetry so developmental context travels with every stored experience and Prometheus gauge.
+    *   Added focused tests to lock stage-bound ratio enforcement, transition reseeding, and LifeStageManager progressions.
+*   **2025-10-18T15:52:43-04:00**: Added a Dreamer-style latent world model with imagination rollouts.
+    *   Implemented an RSSM backbone, rollout API, and Dreamer-specific optimizers plus regression tests covering KL math and viability rollouts.
+    *   Wired factory/trainer hooks so `world_model.type: "dreamer"` toggles the new module, updates intrinsic reward flows, and exposes enablement steps in docs and walkthroughs.
+*   **2025-10-18T11:18:51-04:00**: Captured Growth-Mimetic roadmap status and filed implementation issues.
+    *   Authored a technology pitch summarizing stage dynamics, biodiversity simulators, and lineage memory plans with milestone checklists.
+    *   Opened detailed issue briefs for the Dreamer upgrade, EEA++, biodiversity fabric, and transgenerational memory weave initiatives.
+*   **2025-10-16T19:15:05-04:00**: Introduced life-stage management scaffolding and telemetry visibility.
+    *   Created `LifeStageManager` to parse viability schemas, emit stage metrics, and preview timelines in the CLI walkthrough.
+    *   Expanded Prometheus gauges to report stage index, progress, affect bands, and transition counters for dashboarding.
+*   **2025-10-13T09:00:20-04:00**: Added a heuristic multi-agent controller driven by the EEA scaffold.
+    *   Built `EEAMultiAgentPolicy` with observation splitting, behavior-conditioned movement heuristics, and deterministic seeding for reproducible swarm runs.
+    *   Extended replay tests to confirm stage indices propagate alongside joint transitions.
+*   **2025-10-04T09:02:05-04:00**: Implemented a Genetic Algorithm (GA) engine for meta-optimization.
+    *   Added a new `evolution` module containing a generic GA/ES engine, NSGA-II selection, and operators for mutation and crossover.
+    *   Integrated the GA engine into the main CLI, allowing users to run GA-based experiments to optimize hyperparameters.
+    *   Included a new test suite for the GA core to ensure its functionality.
+*   **2025-09-30T09:10:05-04:00**: Hardened the LoRA inference utilities for transformer workflows.
+    *   Extended `LoRAInferencePipeline` so tokenizer initialization kwargs stay separate from per-call arguments while exposing an override for generation-time parameters.
+    *   Added guard rails and pytest skips around optional `peft` dependencies alongside a regression test that asserts tokenizer configuration is respected end-to-end.
+*   **2025-09-30T09:05:30-04:00**: Introduced a LoRA-aware inference pipeline with comprehensive coverage.
+    *   Implemented `tools/lora_inference.py` and `tools/__init__.py` to assemble base backbones with one or many adapters, optionally merging them before evaluation.
+    *   Added targeted tests (`tests/test_lora_inference.py`) that fabricate lightweight adapters to validate merge semantics, adapter naming, and callable behavior.
+    *   Declared `peft` and `transformers` dependencies to support Hugging Face model loading within the new tooling.
+*   **2025-09-29T22:16:25-04:00**: Published end-to-end walkthroughs for typical persistence experiments.
+    *   Authored `docs/use_case_walkthroughs.md` with guided exercises for baseline, multi-agent, and adversarial training runs, connecting CLI prompts to telemetry and testing artifacts.
+    *   Expanded `docs/ui_ux_improvements.md` with beginner-centric onboarding concepts like guided tours, template libraries, and interactive glossaries.
+    *   Linked the README to the walkthroughs so newcomers can navigate from setup instructions to practical scenarios.
+*   **2025-09-29T22:01:16-04:00**: Documented optimizer and adapter tactics for resilient training.
+    *   Created `docs/training_resilience.md` outlining persistence-friendly optimizers plus LoRA and PEFT strategies aligned with the fire-reset philosophy.
+    *   Highlighted the new guide in the README to steer training loop designers toward recovery-aware tooling.
+*   **2025-09-29T11:51:24-04:00**: Elevated the CLI walkthrough with visual progress cues and summaries.
+    *   Introduced a `StepProgressTracker`, Rich-powered panels, and confirmation cards in `main.py` so users can see step counts, validated inputs, and consolidated selections.
+    *   Tweaked numeric prompts to echo accepted values and ensured the walkthrough culminates in a top-level configuration digest.
+    *   Added `rich` to the dependency list to support the upgraded console rendering.
+*   **2025-09-29T11:34:13-04:00**: Captured UI/UX progression opportunities in dedicated documentation.
+    *   Authored `docs/ui_ux_improvements.md` to catalog CLI enhancements, training visuals, telemetry dashboards, onboarding aids, and accessibility options.
+    *   Emphasized progress indicators, celebratory milestones, and documentation touchpoints to keep contributors aligned on experiential goals.
+*   **2025-09-29T10:35:25-04:00**: Captured the long-term roadmap and review guidance in dedicated documentation.
+    *   Authored `docs/roadmap.md` to record wins, refactor priorities, testing plans, and milestone checklists for future contributors.
+    *   Documented actionable steps for README modularization, API hygiene, CI coverage, and developer experience improvements.
+    *   Highlighted near-term verification, collaboration, and benchmarking tasks to keep the repository aligned with the architecture vision.
+*   **2025-09-29T10:34:54-04:00**: Streamlined the top-level README around quick start usage.
+    *   Removed internal review checklists so the README now emphasizes onboarding instructions and the progress journal.
+    *   Focused the "Getting Started" narrative on the Conda workflow and interactive CLI entry point for running experiments.
+    *   Preserved the historical changelog while paving the way for deeper docs to live in `docs/`.
+*   **2025-09-29T10:32:17-04:00**: Deepened the CLI walkthrough for configuring training runs.
+    *   Added interactive flows in `main.py` that let users tune epochs, update cadence, learning rates, and shield amortization thresholds before launching training.
+    *   Enabled optional prompts for resizing network capacity and curriculum schedules, keeping advanced knobs accessible without editing YAML by hand.
+    *   Synced defaults in `config.yaml` with the new questionnaire so saved configurations match the guided selections.
+*   **2025-09-28T10:02:12+00:00**: Added automated data collection around the viability frontier.
+    *   Implemented a configurable `NearBoundaryBuffer` (`buffers/near_boundary.py`) that captures internal states with safety
+        probabilities near the decision boundary and replays them during updates.
+    *   Extended the trainer and coordinator so the `ViabilityApproximator` (and ensemble variants) receive extra supervision
+        on these ambiguous samples, improving shield accuracy without inducing extra risk.
+    *   Updated `config.yaml` and the viability schema to expose `viability.near_boundary_buffer` controls and documented the
+        feature in `docs/theory.md`.
+    *   Added targeted unit tests for the buffer to guarantee sampling and filtering behave as expected.
+*   **2025-09-28T09:14:00+00:00**: Improved developer experience by simplifying setup and usage.
+    *   Added an `environment.yml` file to allow for easy environment setup using Conda.
+    *   Created a "Getting Started" section in `README.md` to document the environment setup process and the existing interactive CLI.
+*   **2025-09-28T08:44:41+00:00**: Implemented an interactive command-line interface (CLI) in `main.py`.
+    *   The new CLI guides users through selecting an experiment type (e.g., standard single-agent, multi-agent, robust agent) or building a custom configuration.
+    *   This eliminates the need for manual `config.yaml` editing for most use cases, making the framework more user-friendly.
+    *   The underlying `ComponentFactory` and validation logic were refactored to support dynamic configuration generation.
+*   **2025-09-28T07:48:00+00:00**: Improved framework robustness and observability.
+    *   Strengthened the testing framework by adding comprehensive test suites for the multi-agent environment (`tests/test_multiagent_env.py`) and the safety shield (`tests/test_shield.py`).
+    *   Implemented a fail-fast configuration validation system by creating a master JSON schema (`schemas/config.schema.json`) and integrating it into the application's startup sequence.
+    *   Added detailed logging to the `Shield` and `ResourceAllocator` components to provide debug traces for safety and resource management decisions.
+*   **2025-09-28T05:07:24+00:00**: Completed major framework components and documentation alignment.
+    *   Replaced the mock Hamilton-Jacobi reachability analysis with a functional, grid-based backward reachability implementation in `tools/hj_reachability/compute_viability.py`.
+    *   Expanded the constraint governance feature by updating `schemas/viability.schema.json` to a more detailed, structured format and modified `config.yaml` and `environments/grid_life.py` to use the new schema.
+    *   Refactored the self-maintenance logic into a dedicated `MaintenanceManager` class in `environments/maintenance_tasks.py` for improved modularity.
+    *   Updated the `README.md` to accurately reflect the current state of the project, including removing outdated sections and updating configuration examples.
+*   **2025-09-27T18:49:00+00:00**: Implemented the "Governance + telemetry" feature.
+    *   Created an `ops/` directory for operational components.
+    *   Added a `TelemetryManager` (`ops/telemetry.py`) that uses `prometheus-client` to expose key training metrics (e.g., survival time, constraint violations, shield trigger rate) via an HTTP endpoint.
+    *   Defined a set of sample alerting rules in `ops/alerts.yml` for use with a Prometheus server.
+    *   Integrated the `TelemetryManager` into the main training loop (`systems/coordinator.py` and `utils/trainer.py`) to provide real-time monitoring of the agent's performance and stability.
+    *   Added a `telemetry` section to `config.yaml` to enable and configure the feature.
+*   **2025-09-27T15:19:51+00:00**: Implemented a multi-agent persistence architecture (CTDE).
+    *   Created `MultiAgentGridLifeEnv` with a dictionary-based API for managing multiple agents in a shared world.
+    *   Implemented a `SharedSAC` agent using parameter sharing and role embeddings for efficient homogeneous multi-agent learning.
+    *   Added a `MultiAgentTrainer` and `ReplayMA` buffer to handle the centralized training loop.
+    *   Integrated a `ResourceAllocator` for proportional resource distribution and a `CBFCoupler` for collision avoidance.
+    *   The entire multi-agent system is configurable via the `multiagent` and `agent_types` sections in `config.yaml`.
+*   **2025-09-27T13:32:29+00:00**: Implemented interpretability for the safety path.
+    *   Added a `SafetyProbe` component (`components/safety_probe.py`) to predict individual constraint margins, providing insight into the agent's safety status.
+    *   Created a `SafetyReporter` (`utils/reporting.py`) to generate detailed JSON logs explaining why the safety shield modified an action.
+    *   The environment now calculates and provides true constraint margins, which are used to train the probe.
+    *   The feature is fully configurable via the `safety_probe` section in `config.yaml`.
+*   **2025-09-27T13:29:35+00:00**: Implemented adversarial robustness.
+    *   Added an `Adversary` component (`components/adversary.py`) that uses PGD to generate adversarial examples.
+    *   Created a `RobustTrainer` (`utils/robust_trainer.py`) to handle adversarial training.
+    *   The `SAC` agent's critic is now trained on these adversarial examples to improve robustness.
+    *   The feature is configurable via the `adversarial` section in `config.yaml`.
+*   **2025-09-27T13:13:49+00:00**: Implemented self-maintenance behaviors.
+    *   Added "refuel," "cool-down," and "repair" stations to the `GridLifeEnv`.
+    *   These tasks incur a small configurable penalty, encouraging the agent to learn strategic resource management.
+    *   Updated `config.yaml` with a `maintenance` section to control these features.
+*   **2025-09-27T13:07:11+00:00**: Implemented the Hamilton-Jacobi (HJ) Reachability analysis scaffolding.
+    *   Created `tools/hj_reachability/compute_viability.py` as a placeholder for offline viable set computation.
+    *   Added `scripts/distill_viability.py` to train the `ViabilityApproximator` by distilling knowledge from the pre-computed set.
+    *   This establishes the workflow for using formal methods to define safety and then transferring that knowledge to a neural network.
+*   **2025-09-27T12:40:00+00:00**: Implemented the "Resource Accounting / Bounded Rationality" feature.
+    *   Created a `BudgetMeter` component (`components/budget_meter.py`) to track resource consumption (e.g., energy, computation time) over an episode.
+    *   Integrated the `BudgetMeter` into the main training loop (`utils/trainer.py`), which now terminates an episode and applies a configurable penalty if the agent's budget is exhausted.
+    *   Added a `budgets` section to `config.yaml` to allow enabling and configuring this feature.
+*   **2025-09-27T12:25:30+00:00**: Implemented several key system-level features to enhance robustness and verifiability.
+    *   Added a `PersistenceManager` (`systems/persistence.py`) for atomic checkpointing and a `DegradedModePolicy` (`policies/degraded_mode.py`) for safe fallbacks.
+    *   Established a verification harness with property-based safety tests (`tests/spec_safety_test.py`) and a scenario fuzzer (`tools/fuzz_scenarios.py`).
+    *   Created an evaluation suite (`benchmarks/persist_suite/`) with scenarios for regime shifts like sensor dropout, dynamics drift, and rare hazards.
+    *   Implemented a data contract (`schemas/viability.schema.json`) and a validation script (`utils/validate_config.py`) to ensure configuration integrity.
+*   **2025-09-27T19:16:45+00:00**: Implemented the "Population-level persistence" extension by adding an `EnsembleShield`.
+    *   Created a `population/` directory to house all population-based components.
+    *   Implemented the `EnsembleShield` (`population/ensemble_shield.py`), which aggregates safety votes from multiple `ViabilityApproximator` models.
+    *   The `EnsembleShield` supports multiple voting mechanisms, such as "veto_if_any_unsafe" and "majority_vote."
+    *   Updated the `ComponentFactory` and `config.yaml` to allow for the creation and configuration of the `EnsembleShield`.
+    *   Modified the `Trainer` to train all models in the `viability_ensemble`.
+*   **2025-09-27T12:07:30+00:00**: Implemented a continual learning system to mitigate catastrophic forgetting.
+    *   Created a `RehearsalBuffer` (`buffers/rehearsal.py`) to store past experiences using reservoir sampling.
+    *   Implemented a `ContinualLearningManager` (`components/continual.py`) that uses Elastic Weight Consolidation (EWC) to protect important neural network weights.
+    *   Integrated the EWC penalty into the SAC agent's loss function and added a periodic consolidation step to the main training loop.
+*   **2025-09-27T18:00:00+00:00**: Implemented advanced safety and robustness features as outlined in the roadmap.
+    *   Added a Control Barrier Function (CBF) layer (`components/cbf_layer.py`) to provide formal safety guarantees by solving a Quadratic Program to filter actions. This includes a `DynamicsAdapter` (`components/dynamics_adapter.py`) for linearizing the internal model.
+    *   Implemented a `ConstraintManager` (`components/constraint_manager.py`) that uses dual ascent to automatically tune homeostatic penalty multipliers, enforcing a target violation rate without manual parameter tuning.
+    *   Introduced an energy-based Out-of-Distribution (OOD) detector (`components/ood_detector.py`) to identify novel states and a `SafeFallbackPolicy` (`policies/safe_fallback.py`) to ensure the agent takes a safe action when encountering them.
+*   **2025-09-27T17:31:45+00:00**: Refactored the codebase for improved modularity, maintainability, and performance.
+    *   Introduced a `ComponentFactory` (`utils/factory.py`) to centralize the initialization of all framework components.
+    *   Created a `Trainer` class (`utils/trainer.py`) to encapsulate the main training loop and update logic, simplifying `train.py`.
+    *   Added device management for GPU acceleration, automatically moving models and tensors to a CUDA device if available.
+    *   Optimized the data pipeline by modifying the `ReplayBuffer` to return tensors directly on the correct device, reducing overhead.
+*   **2025-09-27T16:44:07+00:00**: Established a testing framework and added unit tests for core components.
+    *   Created a `tests/` directory to house all test suites.
+    *   Added `tests/test_components.py` with unit tests for `Homeostat`, `ViabilityApproximator`, and `InternalModel`.
+    *   These tests verify the correctness of reward calculation, model training, and prediction logic, improving the project's robustness and maintainability.
+*   **2025-09-27T08:11:30+00:00**: Implemented a comprehensive evaluation and metrics logging system.
+    *   Created an `Evaluator` class in `utils/evaluation.py` to handle logging.
+    *   The system now tracks and logs key metrics from the `README.md` file, including survival time, constraint satisfaction rates, and policy entropy.
+    *   Metrics are saved to `training.log` in a structured JSON format for analysis.
+    *   The main training loop in `train.py` was updated to integrate the evaluator.
+*   **2025-09-27T07:22:55+00:00**: Implemented the "Reach-avoid MPC" extension.
+    *   Created a `ReachAvoidMPC` component (`components/reach_avoid_mpc.py`) that uses model-predictive control to plan safe, goal-oriented actions.
+    *   The MPC planner uses the `LatentWorldModel`, `InternalModel`, and `ViabilityApproximator` to simulate future trajectories and select the best action sequence via the Cross-Entropy Method (CEM).
+    *   Created a new `MPCAgent` (`agents/mpc_agent.py`) to integrate the planner into the training loop.
+    *   Added an `mpc` section to `config.yaml` to enable and configure the MPC agent.
+*   **2025-09-27T14:08:18+00:00**: Implemented the "Risk-sensitive RL" extension.
+    *   Created a `CVAR_SAC` agent (`agents/cvar_sac.py`) that optimizes the Conditional Value at Risk (CVaR) of the return distribution, making the agent risk-averse.
+    *   Implemented a `DistributionalCritic` that learns the return distribution using quantile regression.
+    *   The actor's objective is to maximize the CVaR of the critic's predicted distribution.
+    *   The feature is configurable in `config.yaml` via the `risk_sensitive` section, allowing control over risk-aversion.
+*   **2025-09-27T13:59:05+00:00**: Implemented the "Adaptive setpoints" extension.
+    *   Created a `MetaLearner` component (`components/meta_learner.py`) to dynamically adjust homeostatic setpoints (`mu`) based on long-term performance.
+    *   Integrated the `MetaLearner` into the main training loop (`train.py`), allowing the agent to adapt its internal targets.
+    *   Added a `meta_learning` section to `config.yaml` to control this feature.
+*   **2025-09-27T06:09:46+00:00**: Implemented the 'Empowerment' intrinsic reward module as described in the framework's core concepts.
+    *   Created a new `Empowerment` component (`components/empowerment.py`) that uses a contrastive discriminator (InfoNCE) to calculate intrinsic rewards.
+    *   The component is trained on-the-fly using rollouts from the `LatentWorldModel`.
+    *   Updated `train.py` to support 'empowerment' as a configurable intrinsic reward method.
+    *   Added an `empowerment` section to `config.yaml` for hyperparameters.
+*   **2025-09-26 12:23:24.130399**: Completed Phase 2 of the implementation plan by integrating a surprise-based intrinsic reward.
+    *   Created a `WorldModel` component (`components/world_model.py`) using PyTorch to predict the next observation.
+    *   The prediction error (MSE) of the `WorldModel` is used as the surprise reward (`r_intr`).
+    *   The main training loop (`train.py`) was updated to initialize and train the `WorldModel`.
+    *   The total reward was updated to `r_total = r_task + lambda_H * r_homeo + lambda_I * r_intr`.
+    *   Added `torch` and `pyyaml` to `requirements.txt`.
+*   **2025-09-26 14:54:16.787780**: Completed Phase 3 of the implementation plan by integrating the Viability Shield.
+    *   Created an `InternalModel` (`components/internal_model.py`) to predict the next internal state.
+    *   Created a `ViabilityApproximator` (`components/viability_approximator.py`) to predict the safety of a state.
+    *   Created a `Shield` (`components/shield.py`) to filter unsafe actions.
+    *   Updated the `ReplayBuffer` to store internal states and viability labels.
+    *   Integrated all new components into the main training loop (`train.py`), which now uses the shield to select safe actions and trains the new models.
+*   **2025-09-26 15:17:41.792207**: Implemented "Change 2" from the modernization plan by replacing the surprise-based intrinsic reward with Random Network Distillation (RND).
+    *   Created an `RND` component (`components/rnd.py`) that calculates intrinsic reward based on the prediction error of a randomly initialized target network.
+    *   Updated the main training loop (`train.py`) to use the `RND` component for intrinsic motivation.
+    *   Modified `config.yaml` to allow selecting `"rnd"` as the intrinsic reward type.
+*   **2025-09-26 18:18:45.834302**: Implemented "Change 3" from the modernization plan by amortizing the Safety Shield's computation.
+    *   Created a `SafetyNetwork` component (`components/safety_network.py`) that learns to project unsafe actions to safe ones.
+    *   Updated the `ReplayBuffer` to store both unsafe and safe actions to create a training dataset for the `SafetyNetwork`.
+    *   Modified the `Shield` to operate in two modes: a `search` mode for data collection and an `amortized` mode that uses the trained `SafetyNetwork` for fast projection.
+    *   Updated the main training loop (`train.py`) to train the `SafetyNetwork` and switch the shield's mode after a configured number of steps.
+    *   Added a `safety_network` section to `config.yaml` to control the new component's hyperparameters.
+*   **2025-09-26 18:52:38.574183**: Implemented "Change 1" from the modernization plan by replacing the simple world model with a latent dynamics model.
+    *   Created a `LatentWorldModel` (`components/latent_world_model.py`) with separate `Encoder`, `TransitionModel`, and `Decoder` modules.
+    *   The model is trained on reconstruction and dynamics prediction losses.
+    *   The intrinsic reward is now calculated as the reconstruction error from the predicted latent state, providing a more robust surprise signal.
+    *   Updated `train.py` to use the new latent model and switched `config.yaml` to use `"surprise"` reward.
+*   **2025-09-26 19:15:19.784624**: Implemented "Change 4" from the modernization plan by enabling the `ViabilityApproximator` to learn from safe demonstrations.
+    *   Created a `DemonstrationBuffer` (`components/demonstration_buffer.py`) to load and sample expert data.
+    *   Modified the `ViabilityApproximator` to include a `train_on_demonstrations` method, allowing it to pre-train on safe states.
+    *   Updated the main training loop (`train.py`) to use the new buffer and training method.
+    *   Added a `demonstrations` section to `config.yaml` to specify the data path.
+*   **2025-09-26 20:20:23.540386**: Implemented curriculum learning as described in the "Implementation order."
+    *   Added a `CurriculumScheduler` to `train.py` to gradually increase the weights of persistence rewards (`lambda_homeo`, `lambda_intr`) and tighten the environment's viability constraints over a configurable number of steps.
+    *   The `GridLifeEnv` was updated to support dynamic constraint changes.
+    *   Added a `curriculum` section to `config.yaml` to control the new scheduling feature.
+*   **2025-09-26 20:49:35.720744**: Implemented the "Partial Observability" extension from the roadmap.
+    *   Created a `StateEstimator` component (`components/state_estimator.py`) with a GRU network to predict the internal state from external observations.
+    *   Modified the `GridLifeEnv` to optionally hide the true internal state, simulating partial observability.
+    *   Updated `train.py` to use the `StateEstimator` when partial observability is enabled, feeding the estimated state to the agent and other components.
+    *   Enhanced the `ReplayBuffer` to support sampling of contiguous sequences required for training the recurrent estimator.
+    *   Added `state_estimator` and `partial_observability` configurations to `config.yaml`.

--- a/docs/multiagent.md
+++ b/docs/multiagent.md
@@ -1,0 +1,42 @@
+# Multi-agent Coordination in PERSIST
+
+This guide explains how the cooperative and competitive flows are composed when you enable the multi-agent stack. It complements the onboarding-oriented README by diving into the centralized-training, decentralized-execution (CTDE) architecture and the Biodiversity Fabric Simulator (BFS).
+
+## Architecture overview
+- **Centralized training**: `multiagent/trainer.py` coordinates gradient updates for the shared policies, replay buffers, and viability ensembles.
+- **Decentralized execution**: `multiagent/policies/` exposes per-agent wrappers so each species or role acts autonomously at inference time.
+- **Population governance**: `population/ensemble_shield.py`, `population/lineage/`, and BFS instrumentation maintain viability votes, lineage blending, and environment balance across species.
+- **Experiment control**: `ComponentFactory` and `ExperimentCoordinator` wire the above modules using the `multiagent` and `population` sections from `config.yaml`.
+
+## Cooperative flows
+1. **Role-aware policy sharing**: `multiagent/shared_sac.py` shares actor/critic weights while injecting role embeddings so different agent archetypes can coordinate without duplicating networks.
+2. **Shared replay buffers**: `buffers/replay_ma.py` stores joint transitions and role metadata, unlocking centralized updates and near-boundary sampling for the safety ensemble.
+3. **Viability consensus**: The `EnsembleShield` aggregates safety votes from species-specific viability approximators before projecting actions back to each agent.
+4. **Life-stage synchronization**: When `LifeStageManager` is enabled, the trainer injects life-stage context into both cooperative policy updates and EEA affectors so agents mature together.
+
+## Competitive and adversarial hooks
+- **Adversarial perturbations**: Enabling the `adversarial` block in `config.yaml` adds PGD perturbations via `components/adversary.py`, stress-testing cooperative policies under targeted attacks.
+- **Resource contention**: `components/budget_meter.py` and the maintenance tasks in `environments/grid_life.py` enforce shared energy, cooldown, and repair budgets, forcing agents to negotiate scarce resources.
+- **Shield veto escalation**: Configure `viability_ensemble.voting` to `"veto_if_any_unsafe"` when you want safety votes from risk-sensitive agents to override aggressive teammates.
+
+## Biodiversity Fabric Simulator (BFS)
+The BFS extends the base multi-agent grid into trophic layers and regeneration cycles.
+
+- **Species archetypes**: Define species templates under `population/species/` and reference them via `population.species_catalog` in `config.yaml`.
+- **Succession knobs**: Use `population.successions` to choreograph how species spawn, respawn, and seed lineage memories across life stages.
+- **Telemetry**: BFS scenarios emit richness, trophic stability, and mutualism metrics via the Prometheus gauges registered in `ops/telemetry.py`.
+
+## Configuration quick reference
+| Key | Purpose |
+| --- | --- |
+| `multiagent.enabled` | Toggles centralized multi-agent training. |
+| `multiagent.trainer` | Selects the trainer (e.g., `shared_sac`). |
+| `multiagent.roles` | Lists role identifiers and embeddings for each species or policy head. |
+| `population.ensemble_shield` | Configures how safety votes are aggregated. |
+| `population.lineage` | Enables lineage memory, respawn initialization, and Fisher-masked blending. |
+| `population.fire_cycle` | Controls regeneration cadence for the fire-reset philosophy. |
+
+## Further reading
+- [docs/use_case_walkthroughs.md](docs/use_case_walkthroughs.md): step-by-step BFS and multi-agent exercises.
+- [docs/EEA.md](docs/EEA.md): how affective agents integrate into lineage-aware multi-agent runs.
+- [docs/growth_mimetic_technologies.md](docs/growth_mimetic_technologies.md): roadmap context for biodiversity and lineage mechanics.

--- a/docs/theory.md
+++ b/docs/theory.md
@@ -1,5 +1,16 @@
 PERSIST: A Persistence-Centric Agent Framework
 
+## Philosophical foundations
+
+| Domain | Concept | Parallel in Persistence |
+| --- | --- | --- |
+| **Biology** | Autopoiesis (Maturana & Varela) | Systems maintain themselves through internal regeneration |
+| **Cybernetics** | Homeostatic feedback loops | Error correction as persistence strategy |
+| **Reinforcement Learning** | Reward ≈ survival signal | Long-term viability replaces immediate reward |
+| **Thermodynamics** | Entropy management | Fire as controlled entropy reduction |
+| **Philosophy of Mind** | Process ontology | “Being” is replaced by “becoming” — existence is cyclical |
+| **Mythology** | Phoenix cycle | Destruction and rebirth as persistence through transformation |
+
 Core concepts State s_t = [o_t, x_t]: external observation o_t + internal/homeostatic variables x_t (e.g., energy, temperature, integrity).
 Dynamics x_{t+1} = f_\theta(x_t, a_t, o_t): learned or known internal-state transition.
 


### PR DESCRIPTION
## Summary
- overhaul the README to emphasize overview, quickstart, and a configuration map that distinguishes core and optional modules
- add a dedicated multi-agent guide and relocate the philosophical framing into the theory document
- move the historical progress log into docs/changelog.md while keeping a fresh progress entry in the README

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68fcdbcbd15c832c8da1435b43dd831a