### PR TITLE
Add lineage benchmarking sweeps and telemetry visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ The roadmap documents how growth-inspired systems land in the stack:
 - [docs/changelog.md](docs/changelog.md): full historical progress timeline.
 
 ### Progress Updates
+* **2025-10-27T22:15:00+00:00**: Automated lineage resilience sweeps and telemetry deltas.
+  * Added a `TMWRecoveryBenchmark` harness to sweep LoRA ranks and ancestor budgets across seeds, aggregating recovery gains directly from scenario definitions.
+  * Threaded biodiversity-aware lineage selection and lineage delta gauges into the coordinator/telemetry stack so respawns respect species constraints and expose live blend metrics.
 * **2025-10-27T16:30:00+00:00**: Modularized onboarding docs and relocated deep dives.
   * Rebuilt the README around overview, quickstart, and configuration maps so newcomers can stand up experiments without sifting through theoretical derivations.
   * Added `docs/changelog.md` for the full progress journal and `docs/multiagent.md` for cooperative/competitive walkthroughs, keeping deep content a click away while preserving navigability.

--- a/benchmarks/persist_suite/harness.py
+++ b/benchmarks/persist_suite/harness.py
@@ -1,0 +1,345 @@
+"""Benchmark harness utilities for the Persist evaluation suite."""
+
+from __future__ import annotations
+
+import copy
+import itertools
+import statistics
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import (
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    MutableMapping,
+    Optional,
+    Sequence,
+)
+
+import yaml
+
+from main import run_experiment
+
+MetricDict = Mapping[str, float]
+
+__all__ = [
+    "BaselineResult",
+    "BenchmarkSweepReport",
+    "SweepRunResult",
+    "SweepSummary",
+    "TMWRecoveryBenchmark",
+]
+
+
+@dataclass(frozen=True)
+class BaselineResult:
+    """Stores per-seed baseline metrics."""
+
+    seed: int
+    metrics: Dict[str, float]
+
+
+@dataclass(frozen=True)
+class SweepRunResult:
+    """Captures metrics for a lineage-enabled sweep run."""
+
+    seed: int
+    metrics: Dict[str, float]
+    delta_from_baseline: Dict[str, float]
+
+
+@dataclass(frozen=True)
+class SweepSummary:
+    """Aggregated statistics for a specific (rank, ancestor) combination."""
+
+    lora_rank: int
+    max_ancestors: int
+    mean_metrics: Dict[str, float]
+    mean_delta_from_baseline: Dict[str, float]
+    per_seed: List[SweepRunResult] = field(default_factory=list)
+    improvement_confirmed: Dict[str, bool] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class BenchmarkSweepReport:
+    """Full sweep report including baselines and aggregated summaries."""
+
+    scenario: str
+    metrics: Sequence[str]
+    baselines: List[BaselineResult]
+    sweeps: Mapping[str, List[SweepSummary]]
+
+
+class TMWRecoveryBenchmark:
+    """Orchestrates sweeps for the Transgenerational Memory Weave scenario."""
+
+    def __init__(
+        self,
+        scenario_path: str | Path,
+        *,
+        base_config_path: str | Path = "config.yaml",
+    ) -> None:
+        self.scenario_path = Path(scenario_path)
+        if not self.scenario_path.exists():
+            raise FileNotFoundError(
+                f"Scenario definition not found: {self.scenario_path}"
+            )
+
+        with self.scenario_path.open("r", encoding="utf-8") as handle:
+            self.scenario = yaml.safe_load(handle)
+
+        base_config_path = Path(base_config_path)
+        if not base_config_path.exists():
+            raise FileNotFoundError(f"Base config not found: {base_config_path}")
+
+        with base_config_path.open("r", encoding="utf-8") as handle:
+            self.base_config = yaml.safe_load(handle)
+
+        setup = self.scenario.get("setup") or {}
+        metrics = setup.get("metrics") or []
+        self.metric_names: List[str] = [
+            entry["name"] for entry in metrics if "name" in entry
+        ]
+
+        runs = setup.get("runs") or {}
+        if not runs:
+            raise ValueError(
+                "Scenario must define at least one run entry under setup.runs."
+            )
+        self.runs: Dict[str, Dict[str, object]] = runs
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def run_sweep(
+        self,
+        *,
+        lora_ranks: Sequence[int],
+        ancestor_counts: Sequence[int],
+        seeds: Sequence[int],
+        run_experiment_fn: (
+            Callable[[MutableMapping[str, object]], object] | None
+        ) = None,
+        metric_extractor: (
+            Callable[[object, Mapping[str, object]], MetricDict] | None
+        ) = None,
+    ) -> BenchmarkSweepReport:
+        """Execute the configured sweep across seeds and lineage parameters."""
+
+        if not lora_ranks:
+            raise ValueError("At least one LoRA rank must be provided.")
+        if not ancestor_counts:
+            raise ValueError("At least one ancestor count must be provided.")
+        if not seeds:
+            raise ValueError("At least one seed must be provided.")
+
+        runner = run_experiment_fn or run_experiment
+        extractor = metric_extractor or (lambda result, _: result)  # type: ignore[assignment]
+
+        baseline_name = self._resolve_baseline_run_name()
+        lineage_runs = self._resolve_lineage_run_names(excluding={baseline_name})
+        if not lineage_runs:
+            raise ValueError("Scenario must include at least one lineage-enabled run.")
+
+        baseline_metrics = self._compute_baselines(
+            baseline_name,
+            seeds=seeds,
+            runner=runner,
+            extractor=extractor,
+        )
+
+        sweeps: Dict[str, List[SweepSummary]] = {}
+        for run_name in lineage_runs:
+            sweeps[run_name] = self._compute_lineage_sweeps(
+                run_name,
+                lora_ranks=lora_ranks,
+                ancestor_counts=ancestor_counts,
+                seeds=seeds,
+                runner=runner,
+                extractor=extractor,
+                baseline_lookup={
+                    result.seed: result.metrics for result in baseline_metrics
+                },
+            )
+
+        return BenchmarkSweepReport(
+            scenario=str(self.scenario_path),
+            metrics=self.metric_names,
+            baselines=baseline_metrics,
+            sweeps=sweeps,
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _compute_baselines(
+        self,
+        run_name: str,
+        *,
+        seeds: Sequence[int],
+        runner: Callable[[MutableMapping[str, object]], object],
+        extractor: Callable[[object, Mapping[str, object]], MetricDict],
+    ) -> List[BaselineResult]:
+        overrides = self.runs[run_name]
+        results: List[BaselineResult] = []
+        for seed in seeds:
+            config = self._build_run_config(overrides, seed)
+            outcome = runner(config)
+            metrics = self._extract_metrics(extractor(outcome, config))
+            results.append(BaselineResult(seed=seed, metrics=metrics))
+        return results
+
+    def _compute_lineage_sweeps(
+        self,
+        run_name: str,
+        *,
+        lora_ranks: Sequence[int],
+        ancestor_counts: Sequence[int],
+        seeds: Sequence[int],
+        runner: Callable[[MutableMapping[str, object]], object],
+        extractor: Callable[[object, Mapping[str, object]], MetricDict],
+        baseline_lookup: Mapping[int, Dict[str, float]],
+    ) -> List[SweepSummary]:
+        overrides = self.runs[run_name]
+        summaries: List[SweepSummary] = []
+
+        for rank, ancestor_count in itertools.product(lora_ranks, ancestor_counts):
+            per_seed_results: List[SweepRunResult] = []
+            delta_accumulator: Dict[str, List[float]] = {
+                name: [] for name in self.metric_names
+            }
+            metric_accumulator: Dict[str, List[float]] = {
+                name: [] for name in self.metric_names
+            }
+
+            for seed in seeds:
+                config = self._build_run_config(
+                    overrides,
+                    seed,
+                    lineage_params={
+                        "lora_rank": int(rank),
+                        "max_ancestors": int(ancestor_count),
+                    },
+                )
+                outcome = runner(config)
+                metrics = self._extract_metrics(extractor(outcome, config))
+                baseline_metrics = baseline_lookup[seed]
+                deltas = {
+                    metric: baseline_metrics.get(metric, 0.0) - metrics.get(metric, 0.0)
+                    for metric in self.metric_names
+                }
+
+                for metric, value in metrics.items():
+                    if metric in metric_accumulator:
+                        metric_accumulator[metric].append(value)
+                for metric, value in deltas.items():
+                    if metric in delta_accumulator:
+                        delta_accumulator[metric].append(value)
+
+                per_seed_results.append(
+                    SweepRunResult(
+                        seed=seed,
+                        metrics=metrics,
+                        delta_from_baseline=deltas,
+                    )
+                )
+
+            mean_metrics = {
+                metric: statistics.fmean(values)
+                for metric, values in metric_accumulator.items()
+                if values
+            }
+            mean_deltas = {
+                metric: statistics.fmean(values)
+                for metric, values in delta_accumulator.items()
+                if values
+            }
+            improvement_flags = {
+                metric: all(value > 0 for value in values)
+                for metric, values in delta_accumulator.items()
+                if values
+            }
+
+            summaries.append(
+                SweepSummary(
+                    lora_rank=int(rank),
+                    max_ancestors=int(ancestor_count),
+                    mean_metrics=mean_metrics,
+                    mean_delta_from_baseline=mean_deltas,
+                    per_seed=per_seed_results,
+                    improvement_confirmed=improvement_flags,
+                )
+            )
+
+        return summaries
+
+    def _build_run_config(
+        self,
+        overrides: Mapping[str, object],
+        seed: int,
+        lineage_params: Optional[Mapping[str, int]] = None,
+    ) -> MutableMapping[str, object]:
+        config = copy.deepcopy(self.base_config)
+        config["seed"] = int(seed)
+        self._deep_update(config, overrides)
+
+        if lineage_params:
+            lineage_section = config.setdefault("lineage", {})
+            if not isinstance(lineage_section, dict):
+                raise TypeError(
+                    "Config lineage section must be a dictionary when overriding."
+                )
+            for key, value in lineage_params.items():
+                lineage_section[key] = int(value)
+
+        return config
+
+    def _deep_update(
+        self,
+        target: MutableMapping[str, object],
+        overrides: Mapping[str, object],
+    ) -> None:
+        for key, value in overrides.items():
+            if isinstance(value, Mapping):
+                existing = target.get(key)
+                if isinstance(existing, MutableMapping):
+                    self._deep_update(existing, value)
+                else:
+                    target[key] = copy.deepcopy(value)
+            else:
+                target[key] = copy.deepcopy(value)
+
+    def _extract_metrics(self, raw: Mapping[str, object]) -> Dict[str, float]:
+        metrics: Dict[str, float] = {}
+        for name in self.metric_names:
+            value = raw.get(name)
+            if value is None:
+                continue
+            try:
+                metrics[name] = float(value)
+            except (TypeError, ValueError):
+                continue
+        return metrics
+
+    def _resolve_baseline_run_name(self) -> str:
+        for run_name, overrides in self.runs.items():
+            lineage_cfg = overrides.get("lineage", {})
+            enabled = False
+            if isinstance(lineage_cfg, Mapping):
+                enabled = bool(lineage_cfg.get("enabled", False))
+            if not enabled:
+                return run_name
+        raise ValueError("No baseline run (with lineage disabled) found in scenario.")
+
+    def _resolve_lineage_run_names(self, *, excluding: Iterable[str]) -> List[str]:
+        excluded = set(excluding)
+        lineage_runs: List[str] = []
+        for run_name, overrides in self.runs.items():
+            if run_name in excluded:
+                continue
+            lineage_cfg = overrides.get("lineage", {})
+            if isinstance(lineage_cfg, Mapping) and lineage_cfg.get("enabled", False):
+                lineage_runs.append(run_name)
+        return lineage_runs

--- a/docs/growth_mimetic_devlog/2025-10-26-lineage-tmw.md
+++ b/docs/growth_mimetic_devlog/2025-10-26-lineage-tmw.md
@@ -17,6 +17,6 @@
 - Safety network inheritance stabilized amortized shielding within two episodes, avoiding the cold-start spike observed in prior checkpoints.
 
 ## Next Steps
-- Extend benchmarking harnesses to sweep different LoRA ranks and ancestor counts, confirming the observed recovery gains across seeds.
-- Integrate multi-agent lineage selection heuristics so species-specific policies respect biodiversity constraints when respawning.
-- Surface lineage deltas in telemetry dashboards for richer, live experiment diagnostics.
+- ✅ Extend benchmarking harnesses to sweep different LoRA ranks and ancestor counts, confirming the observed recovery gains across seeds.
+- ✅ Integrate multi-agent lineage selection heuristics so species-specific policies respect biodiversity constraints when respawning.
+- ✅ Surface lineage deltas in telemetry dashboards for richer, live experiment diagnostics.

--- a/multiagent/lineage/__init__.py
+++ b/multiagent/lineage/__init__.py
@@ -1,7 +1,7 @@
 """Lineage utilities enabling the Transgenerational Memory Weave (TMW)."""
 
 from .archive import LineageArchive, LineageMetadata, LineageRecord
-from .blending import LineageBlender, BlendConfig
+from .blending import BlendConfig, BlendOutcome, LineageBlender
 from .fisher import estimate_actor_fisher, estimate_viability_fisher
 
 __all__ = [
@@ -10,6 +10,7 @@ __all__ = [
     "LineageRecord",
     "LineageBlender",
     "BlendConfig",
+    "BlendOutcome",
     "estimate_actor_fisher",
     "estimate_viability_fisher",
 ]

--- a/multiagent/lineage/blending.py
+++ b/multiagent/lineage/blending.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, Iterable, Optional
+from typing import Dict, Iterable, Optional, Tuple
 
 import torch
 
@@ -17,6 +17,26 @@ class BlendConfig:
     alpha: float = 0.5
     lora_rank: int = 8
     max_ancestors: int = 3
+
+
+@dataclass
+class BlendOutcome:
+    """Summary statistics describing the applied lineage blend."""
+
+    alpha: float
+    lora_rank: int
+    ancestors_used: int
+    delta_norms: Dict[str, float]
+
+    def as_dict(self) -> Dict[str, float]:
+        payload: Dict[str, float] = {
+            "alpha": float(self.alpha),
+            "lora_rank": float(self.lora_rank),
+            "ancestors": float(self.ancestors_used),
+        }
+        for component, value in self.delta_norms.items():
+            payload[f"{component}_delta_norm"] = float(value)
+        return payload
 
 
 class LineageBlender:
@@ -36,15 +56,15 @@ class LineageBlender:
         safety_network: Optional[torch.nn.Module],
         ancestors: Iterable[LineageRecord],
         config: BlendConfig,
-    ) -> None:
+    ) -> Optional[BlendOutcome]:
         """Blend lineage knowledge directly into the provided agent."""
 
         ancestors = list(ancestors)
         if not ancestors:
-            return
+            return None
 
         policy_state = agent.get_state()
-        blended_policy = self._blend_state_dict(
+        blended_policy, used_policy, policy_delta = self._blend_state_dict(
             base_state=policy_state,
             ancestors=[
                 record.policy_state for record in ancestors if record.policy_state
@@ -58,6 +78,11 @@ class LineageBlender:
             # Reset optimizers; new lineage should start with fresh momentum.
             agent.load_optimizer_state({})
 
+        delta_norms: Dict[str, float] = {}
+        ancestors_used = used_policy
+        if policy_delta is not None:
+            delta_norms["policy"] = policy_delta
+
         if viability_model is not None:
             viability_state = viability_model.state_dict()
             ancestor_viability = [
@@ -65,13 +90,16 @@ class LineageBlender:
                 for record in ancestors
                 if record.viability_state is not None
             ]
-            blended_viability = self._blend_state_dict(
+            blended_viability, used_viability, viability_delta = self._blend_state_dict(
                 base_state=viability_state,
                 ancestors=ancestor_viability,
                 fisher_masks=[record.fisher_mask for record in ancestors],
                 config=config,
             )
             viability_model.load_state_dict(blended_viability)
+            ancestors_used = max(ancestors_used, used_viability)
+            if viability_delta is not None:
+                delta_norms["viability"] = viability_delta
 
         if safety_network is not None:
             safety_state = safety_network.state_dict()
@@ -81,13 +109,16 @@ class LineageBlender:
                 if record.safety_state is not None
             ]
             if ancestor_safety:
-                blended_safety = self._blend_state_dict(
+                blended_safety, used_safety, safety_delta = self._blend_state_dict(
                     base_state=safety_state,
                     ancestors=ancestor_safety,
                     fisher_masks=[record.fisher_mask for record in ancestors],
                     config=config,
                 )
                 safety_network.load_state_dict(blended_safety)
+                ancestors_used = max(ancestors_used, used_safety)
+                if safety_delta is not None:
+                    delta_norms["safety"] = safety_delta
 
         affect_buffer = getattr(agent, "affect_buffer", None)
         if affect_buffer is not None:
@@ -96,6 +127,13 @@ class LineageBlender:
                     continue
                 self._load_affect_state(affect_buffer, record.affect_state)
                 break  # Only hydrate from the most recent compatible snapshot.
+
+        return BlendOutcome(
+            alpha=float(config.alpha),
+            lora_rank=int(config.lora_rank),
+            ancestors_used=int(ancestors_used),
+            delta_norms=delta_norms,
+        )
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -107,7 +145,7 @@ class LineageBlender:
         ancestors: Iterable[Optional[Dict[str, torch.Tensor]]],
         fisher_masks: Iterable[Optional[Dict[str, torch.Tensor]]],
         config: BlendConfig,
-    ) -> Dict[str, torch.Tensor]:
+    ) -> Tuple[Dict[str, torch.Tensor], int, Optional[float]]:
         state = {name: tensor.clone() for name, tensor in base_state.items()}
         alpha = float(config.alpha)
         rank = max(1, int(config.lora_rank))
@@ -119,7 +157,7 @@ class LineageBlender:
         ][: config.max_ancestors]
 
         if not paired:
-            return state
+            return state, 0, None
 
         for ancestor_state, mask in paired:
             for name, tensor in ancestor_state.items():
@@ -136,7 +174,8 @@ class LineageBlender:
                     mask_tensor = mask[name].to(delta.device)
                     delta = delta * (1.0 / (1.0 + mask_tensor))
                 state[name] = base_tensor + alpha * delta
-        return state
+        delta_norm = self._state_delta_norm(base_state, state)
+        return state, len(paired), delta_norm
 
     def _compute_lora_delta(
         self,
@@ -160,6 +199,19 @@ class LineageBlender:
         s_r = s[:effective_rank]
         vh_r = vh[:effective_rank, :]
         return (u_r * s_r) @ vh_r
+
+    def _state_delta_norm(
+        self,
+        base_state: Dict[str, torch.Tensor],
+        new_state: Dict[str, torch.Tensor],
+    ) -> float:
+        total = 0.0
+        for name, base_tensor in base_state.items():
+            if name not in new_state:
+                continue
+            diff = new_state[name] - base_tensor
+            total += torch.linalg.norm(diff).item() ** 2
+        return total**0.5
 
     def _load_affect_state(self, buffer, state: Dict[str, torch.Tensor]) -> None:
         if hasattr(buffer, "load_state_dict"):

--- a/ops/telemetry.py
+++ b/ops/telemetry.py
@@ -1,5 +1,7 @@
 import time
-from prometheus_client import start_http_server, Gauge, Counter
+from typing import Mapping, Optional
+
+from prometheus_client import Counter, Gauge, start_http_server
 
 
 class TelemetryManager:
@@ -83,6 +85,27 @@ class TelemetryManager:
         self.trophic_stability_rolling_gauge = Gauge(
             "persist_trophic_stability_rolling",
             "Rolling trophic stability over the configured observation window.",
+        )
+
+        self.lineage_ancestors_gauge = Gauge(
+            "persist_lineage_ancestors",
+            "Number of lineage ancestors blended for the target.",
+            ["target"],
+        )
+        self.lineage_alpha_gauge = Gauge(
+            "persist_lineage_alpha",
+            "Lineage blend alpha applied to the target.",
+            ["target"],
+        )
+        self.lineage_lora_rank_gauge = Gauge(
+            "persist_lineage_lora_rank",
+            "LoRA rank used during lineage blending.",
+            ["target"],
+        )
+        self.lineage_delta_norm_gauge = Gauge(
+            "persist_lineage_delta_norm",
+            "Norm of the lineage delta applied to each component.",
+            ["target", "component"],
         )
 
         # Counters (value only goes up)
@@ -263,3 +286,37 @@ class TelemetryManager:
         mutualism_events = metrics.get("mutualism_events")
         if mutualism_events:
             self.mutualism_counter.inc(float(mutualism_events))
+
+    def update_lineage(
+        self,
+        target: str,
+        metrics: Mapping[str, float],
+        *,
+        species_id: Optional[str] = None,
+    ) -> None:
+        """Update telemetry gauges describing lineage blending activity."""
+
+        if not self.enabled:
+            return
+
+        label = target if species_id is None else f"{target}[{species_id}]"
+
+        ancestors = metrics.get("ancestors")
+        if ancestors is not None:
+            self.lineage_ancestors_gauge.labels(target=label).set(float(ancestors))
+
+        alpha = metrics.get("alpha")
+        if alpha is not None:
+            self.lineage_alpha_gauge.labels(target=label).set(float(alpha))
+
+        lora_rank = metrics.get("lora_rank")
+        if lora_rank is not None:
+            self.lineage_lora_rank_gauge.labels(target=label).set(float(lora_rank))
+
+        for key, value in metrics.items():
+            if not key.endswith("_delta_norm"):
+                continue
+            component = key[: -len("_delta_norm")] or "unknown"
+            self.lineage_delta_norm_gauge.labels(target=label, component=component).set(
+                float(value)
+            )

--- a/systems/coordinator.py
+++ b/systems/coordinator.py
@@ -1,5 +1,6 @@
+import copy
 import inspect
-from typing import Dict, Optional
+from typing import Dict, List, Mapping, Optional
 
 import torch
 import numpy as np
@@ -8,9 +9,11 @@ from components.fire_event import FireEvent
 from utils.trainer_utils import log_episode_data, CurriculumScheduler
 from multiagent.lineage import (
     BlendConfig,
+    BlendOutcome,
     LineageArchive,
     LineageBlender,
     LineageMetadata,
+    LineageRecord,
     estimate_actor_fisher,
     estimate_viability_fisher,
 )
@@ -470,6 +473,22 @@ class ExperimentCoordinator:
                         key: list(value) for key, value in affect_targets.items()
                     }
 
+            population_snapshot = getattr(self.env, "population_snapshot", None)
+            if population_snapshot:
+                metrics_dict["population_snapshot"] = copy.deepcopy(population_snapshot)
+
+            global_info = info.get("__all__") if isinstance(info, Mapping) else None
+            if isinstance(global_info, Mapping):
+                metrics_dict["population_metrics"] = {
+                    "species_richness": global_info.get("species_richness"),
+                    "trophic_stability": global_info.get("trophic_stability"),
+                    "trophic_stability_rolling": global_info.get(
+                        "trophic_stability_rolling"
+                    ),
+                    "mutualism_events": global_info.get("mutualism_events"),
+                    "population_stable": global_info.get("population_stable"),
+                }
+
             termination_reason = (
                 "budget_exhausted"
                 if info.get("budget_exhausted")
@@ -597,12 +616,135 @@ class ExperimentCoordinator:
             max_ancestors=int(cfg.get("max_ancestors", 3)),
         )
 
+    def _resolve_blend_config(self, species_id: Optional[str]) -> BlendConfig:
+        if not species_id:
+            return self._blend_config
+        overrides = self.lineage_config.get("species_overrides", {})
+        if not isinstance(overrides, Mapping):
+            return self._blend_config
+        species_override = overrides.get(species_id)
+        if not isinstance(species_override, Mapping):
+            return self._blend_config
+        return BlendConfig(
+            alpha=float(species_override.get("blend_alpha", self._blend_config.alpha)),
+            lora_rank=int(
+                species_override.get("lora_rank", self._blend_config.lora_rank)
+            ),
+            max_ancestors=int(
+                species_override.get("max_ancestors", self._blend_config.max_ancestors)
+            ),
+        )
+
     def _lineage_enabled(self) -> bool:
         return bool(
             self.lineage_archive
             and self.lineage_blender
             and self.lineage_config.get("enabled", False)
         )
+
+    def _resolve_policy_species(self, policy_name: str) -> Optional[str]:
+        mapping = self.lineage_config.get("policy_species", {})
+        if isinstance(mapping, Mapping):
+            for key in (policy_name, f"policy:{policy_name}"):
+                value = mapping.get(key)
+                if isinstance(value, str):
+                    return value
+        species_catalog = getattr(self, "species_catalog", None)
+        if isinstance(species_catalog, Mapping) and policy_name in species_catalog:
+            return policy_name
+        return self._lineage_species
+
+    def _select_lineage_ancestors(
+        self,
+        *,
+        species_id: Optional[str],
+        stage_name: Optional[str],
+        limit: int,
+    ) -> List[LineageRecord]:
+        archive = self.lineage_archive
+        species = species_id or self._lineage_species
+        if not archive or not species:
+            return []
+
+        fetch_limit = max(limit * 2, limit)
+        candidates = list(
+            archive.iter_records(species=species, stage=stage_name, limit=fetch_limit)
+        )
+        if not candidates and stage_name:
+            candidates = list(archive.iter_records(species=species, limit=fetch_limit))
+
+        if not candidates:
+            return []
+
+        filtered = self._filter_lineage_by_biodiversity(candidates, species)
+        if filtered:
+            candidates = filtered
+
+        return candidates[:limit]
+
+    def _filter_lineage_by_biodiversity(
+        self,
+        records: List[LineageRecord],
+        species_id: str,
+    ) -> List[LineageRecord]:
+        if not self._requires_biodiversity_screen():
+            return records
+
+        filtered = [
+            record
+            for record in records
+            if self._record_respects_biodiversity(record, species_id)
+        ]
+        return filtered
+
+    def _requires_biodiversity_screen(self) -> bool:
+        return bool(
+            getattr(self, "population_coordinator", None)
+            and isinstance(getattr(self, "species_catalog", None), Mapping)
+        )
+
+    def _record_respects_biodiversity(self, record, species_id: str) -> bool:
+        metrics = getattr(record.metadata, "metrics", {}) or {}
+        population_metrics = metrics.get("population_metrics") or {}
+        if isinstance(population_metrics, Mapping):
+            stable_flag = population_metrics.get("population_stable")
+            if stable_flag is not None and float(stable_flag) < 1.0:
+                return False
+
+        snapshot = metrics.get("population_snapshot") or {}
+        coordinator = getattr(self, "population_coordinator", None)
+        if coordinator is not None and isinstance(snapshot, Mapping):
+            stable, details = coordinator.evaluate(snapshot)
+            if not stable:
+                return False
+            species_detail = details.get(species_id)
+            if isinstance(species_detail, Mapping) and not species_detail.get(
+                "within_bounds", True
+            ):
+                return False
+
+        species_catalog = getattr(self, "species_catalog", None) or {}
+        species_cfg = (
+            species_catalog.get(species_id, {})
+            if isinstance(species_catalog, Mapping)
+            else {}
+        )
+        population_cfg = (
+            species_cfg.get("population", {})
+            if isinstance(species_cfg, Mapping)
+            else {}
+        )
+        if population_cfg and isinstance(snapshot, Mapping):
+            species_snapshot = snapshot.get(species_id, {})
+            if isinstance(species_snapshot, Mapping):
+                count = int(species_snapshot.get("count", 0))
+                min_count = population_cfg.get("min_count")
+                max_count = population_cfg.get("max_count")
+                if min_count is not None and count < int(min_count):
+                    return False
+                if max_count is not None and count > int(max_count):
+                    return False
+        return True
 
     def _initialize_lineage_for_episode(self, episode: int) -> None:
         if not self._lineage_enabled():
@@ -612,37 +754,64 @@ class ExperimentCoordinator:
 
         manager = getattr(self, "life_stage_manager", None)
         stage_name = manager.current_stage_name() if manager else None
-        limit = int(
-            self.lineage_config.get("max_ancestors", self._blend_config.max_ancestors)
-        )
-        ancestors = list(
-            self.lineage_archive.iter_records(
-                species=self._lineage_species,
-                stage=stage_name,
-                limit=limit,
+        telemetry = getattr(self, "telemetry_manager", None)
+
+        def _update_telemetry(
+            label: str,
+            species_id: Optional[str],
+            outcome: Optional[BlendOutcome],
+        ) -> None:
+            if not outcome or not telemetry or not hasattr(telemetry, "update_lineage"):
+                return
+            payload = outcome.as_dict()
+            telemetry.update_lineage(label, payload, species_id=species_id)
+
+        def _blend_target(
+            target,
+            *,
+            label: str,
+            species_id: Optional[str],
+            viability_model=None,
+            safety_network=None,
+        ) -> None:
+            if target is None:
+                return
+            blend_config = self._resolve_blend_config(species_id)
+            ancestors = self._select_lineage_ancestors(
+                species_id=species_id,
+                stage_name=stage_name,
+                limit=blend_config.max_ancestors,
             )
-        )
-        if not ancestors:
-            ancestors = list(
-                self.lineage_archive.iter_records(
-                    species=self._lineage_species,
-                    limit=limit,
-                )
+            if not ancestors:
+                return
+            outcome = self.lineage_blender.blend_agent(
+                agent=target,
+                viability_model=viability_model,
+                safety_network=safety_network,
+                ancestors=ancestors,
+                config=blend_config,
             )
-        if not ancestors:
-            return
+            _update_telemetry(label, species_id, outcome)
 
         agent = getattr(self, "agent", None)
-        if agent is None:
-            return
+        if agent is not None:
+            _blend_target(
+                agent,
+                label="agent",
+                species_id=self._lineage_species,
+                viability_model=getattr(self, "viability_approximator", None),
+                safety_network=getattr(self, "safety_network", None),
+            )
 
-        self.lineage_blender.blend_agent(
-            agent=agent,
-            viability_model=getattr(self, "viability_approximator", None),
-            safety_network=getattr(self, "safety_network", None),
-            ancestors=ancestors,
-            config=self._blend_config,
-        )
+        policies = getattr(self, "policies", None)
+        if isinstance(policies, Mapping):
+            for policy_name, policy in policies.items():
+                species_id = self._resolve_policy_species(policy_name)
+                _blend_target(
+                    policy,
+                    label=f"policy:{policy_name}",
+                    species_id=species_id,
+                )
 
     def _archive_lineage_snapshot(
         self,

--- a/tests/test_lineage_benchmark_harness.py
+++ b/tests/test_lineage_benchmark_harness.py
@@ -1,0 +1,53 @@
+import math
+
+from benchmarks.persist_suite.harness import TMWRecoveryBenchmark
+
+
+def test_tmw_recovery_benchmark_generates_sweep_results():
+    harness = TMWRecoveryBenchmark("benchmarks/persist_suite/tmw_recovery.yaml")
+
+    call_records = []
+
+    def runner(config):
+        call_records.append(config)
+        lineage_cfg = config.get("lineage", {})
+        seed = config["seed"]
+        if not lineage_cfg.get("enabled", False):
+            return {
+                "reward_recovery_steps": 100.0 + seed,
+                "unsafe_exploration_rate": 0.2,
+            }
+        lora_rank = lineage_cfg.get("lora_rank", 0)
+        max_ancestors = lineage_cfg.get("max_ancestors", 0)
+        return {
+            "reward_recovery_steps": 90.0 - 2.0 * lora_rank + max_ancestors + seed,
+            "unsafe_exploration_rate": 0.05 + 0.01 * max_ancestors,
+        }
+
+    report = harness.run_sweep(
+        lora_ranks=[4],
+        ancestor_counts=[2, 3],
+        seeds=[1, 2],
+        run_experiment_fn=runner,
+        metric_extractor=lambda result, _: result,
+    )
+
+    assert report.metrics == [
+        "reward_recovery_steps",
+        "unsafe_exploration_rate",
+    ]
+    assert len(report.baselines) == 2
+    assert len(report.sweeps) == 1
+
+    sweep_entries = list(report.sweeps.values())[0]
+    assert len(sweep_entries) == 2
+
+    first_entry = sweep_entries[0]
+    assert first_entry.lora_rank == 4
+    assert first_entry.max_ancestors == 2
+    assert math.isclose(
+        first_entry.mean_delta_from_baseline["reward_recovery_steps"], 16.0
+    )
+    assert all(delta > 0 for delta in first_entry.improvement_confirmed.values())
+
+    assert len(call_records) == 6  # 2 baseline runs + 4 sweep runs


### PR DESCRIPTION
## Summary
- add a TMW recovery benchmark harness that sweeps LoRA ranks, ancestor budgets, and seeds while aggregating recovery deltas
- return lineage blending outcomes with delta norms, apply biodiversity-aware ancestor selection, and stream lineage metrics to telemetry
- cover the new harness with unit tests and document the completed lineage next steps in the devlog and README progress log

## Testing
- ruff check .
- mypy agents/
- python -m agents.tests.integration_check
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fd63fa6308832c83f0960c7c3eb10f